### PR TITLE
Add dnscrypt-proxy service and Pi-hole configuration

### DIFF
--- a/docker-compose.arr-stack.yml
+++ b/docker-compose.arr-stack.yml
@@ -352,8 +352,8 @@ services:
       test: ["CMD", "/usr/local/bin/dnsprobe", "google.com", "127.0.0.1:5053"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 45s
+      retries: 2
+      start_period: 30s
 
   # ═══════════════════════════════════════════════════════════════════════════
   # PI-HOLE - DNS server. Enables .lan domains and blocks ads network-wide.

--- a/docker-compose.arr-stack.yml
+++ b/docker-compose.arr-stack.yml
@@ -21,6 +21,7 @@ volumes:
   jellyfin-cache:
   seerr-config:
   bazarr-config:
+  dnscrypt-config:
   pihole-etc-pihole:
   pihole-etc-dnsmasq:
 
@@ -320,14 +321,52 @@ services:
       retries: 2
       start_period: 30s
 
+# ═══════════════════════════════════════════════════════════════════════════
+  # DNSCRYPT-PROXY - DNS over HTTPS/DNSCrypt proxy. Encrypts DNS queries.
+  # No web UI. Used internally by Pi-hole at 172.20.0.6:5053
+  # Protocols: DoH (DNS over HTTPS), DNSCrypt, Anonymized DNS
+  # ═══════════════════════════════════════════════════════════════════════════
+  dnscrypt-proxy:
+    image: klutchell/dnscrypt-proxy:latest
+    container_name: dnscrypt-proxy
+    cap_add:
+      - NET_ADMIN  # Bind to privileged ports
+      - NET_RAW    # Raw socket access for DNS
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:false  # Pi-hole FTL needs setcap to apply capabilities
+    ports:
+      - "${NAS_IP}:5053:5053/tcp"
+      - "${NAS_IP}:5053:5053/udp"
+    networks:
+      arr-stack:
+        ipv4_address: 172.20.0.6
+    volumes:
+      - dnscrypt-config:/config
+    environment:
+      - TZ=${TZ}
+    restart: always
+    logging: *default-logging
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/dnsprobe", "google.com", "127.0.0.1:5053"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 45s
+
   # ═══════════════════════════════════════════════════════════════════════════
   # PI-HOLE - DNS server. Enables .lan domains and blocks ads network-wide.
   # Access: pihole.lan/admin | NAS_IP:8081/admin
   # For: Home Pro + Anywhere setups
+  # Configure upstream DNS: Settings → DNS → Custom = 172.20.0.6#5053
   # ═══════════════════════════════════════════════════════════════════════════
   pihole:
     image: pihole/pihole:2026.02.0
     container_name: pihole
+    depends_on:
+      dnscrypt-proxy:
+        condition: service_healthy
     ports:
       - "${NAS_IP}:53:53/tcp"  # Bind to NAS IP (not 0.0.0.0) to avoid conflict with host dnsmasq on 127.0.0.1:53
       - "${NAS_IP}:53:53/udp"  # NAS_IP MUST be a static IP — DHCP IPs aren't ready at boot, causing exit 128

--- a/docker-compose.arr-stack.yml
+++ b/docker-compose.arr-stack.yml
@@ -327,18 +327,12 @@ services:
   # Protocols: DoH (DNS over HTTPS), DNSCrypt, Anonymized DNS
   # ═══════════════════════════════════════════════════════════════════════════
   dnscrypt-proxy:
-    image: klutchell/dnscrypt-proxy:latest
+    image: klutchell/dnscrypt-proxy:2.1.14
     container_name: dnscrypt-proxy
-    cap_add:
-      - NET_ADMIN  # Bind to privileged ports
-      - NET_RAW    # Raw socket access for DNS
     cap_drop:
       - ALL
     security_opt:
-      - no-new-privileges:false  # Pi-hole FTL needs setcap to apply capabilities
-    ports:
-      - "${NAS_IP}:5053:5053/tcp"
-      - "${NAS_IP}:5053:5053/udp"
+      - no-new-privileges:true
     networks:
       arr-stack:
         ipv4_address: 172.20.0.6

--- a/scripts/configure-apps.sh
+++ b/scripts/configure-apps.sh
@@ -2,7 +2,7 @@
 #
 # Automated app configuration for arr-stack
 #
-# Configures qBittorrent, Sonarr, Radarr, Prowlarr, and Bazarr via their APIs.
+# Configures qBittorrent, Sonarr, Radarr, Prowlarr, Bazarr, and Pi-hole via their APIs.
 # Replaces ~30 manual web UI steps with a single command.
 #
 # Usage:
@@ -27,7 +27,6 @@
 #   - Prowlarr: add indexers (user-specific credentials)
 #   - Seerr: initial Jellyfin login + service connections
 #   - SABnzbd: usenet provider credentials + folder config
-#   - Pi-hole: upstream DNS
 
 # ============================================
 # Source helpers
@@ -484,6 +483,36 @@ sys.exit(0 if 'remove_tags' in mods and 'OCR_fixes' in mods else 1)"; then
 }
 
 # ============================================
+# 5. Pi-hole
+# ============================================
+
+configure_pihole() {
+    log "Configuring Pi-hole..."
+
+    if $DRY_RUN; then
+        dry "Set Pi-hole upstream DNS to dnscrypt-proxy (172.20.0.6#5053)"
+        return
+    fi
+
+    # Check current upstream DNS configuration
+    local current_dns
+    current_dns=$(docker exec pihole pihole-FTL --config dns.upstreams -q 2>/dev/null || true)
+    
+    if [[ "$current_dns" == *"172.20.0.6#5053"* ]]; then
+        skip "Pi-hole: upstream DNS (already using dnscrypt-proxy)"
+    else
+        # Set dnscrypt-proxy as upstream DNS using FTL config
+        if docker exec pihole pihole-FTL --config dns.upstreams '["172.20.0.6#5053"]' >/dev/null 2>&1; then
+            ok "Pi-hole: set upstream DNS to dnscrypt-proxy (172.20.0.6#5053)"
+            # Restart DNS service to apply changes
+            docker exec pihole pihole restartdns >/dev/null 2>&1
+        else
+            fail "Pi-hole: set upstream DNS"
+        fi
+    fi
+}
+
+# ============================================
 # Run all
 # ============================================
 
@@ -498,6 +527,8 @@ echo ""
 configure_prowlarr
 echo ""
 configure_bazarr
+echo ""
+configure_pihole
 
 # ============================================
 # Summary
@@ -521,9 +552,6 @@ echo "  3. Prowlarr: add indexers (torrent/Usenet)"
 echo "  4. Seerr: initial setup + Jellyfin login"
 if $SABNZBD_RUNNING; then
     echo "  5. SABnzbd: usenet provider credentials"
-    echo "  6. Pi-hole: upstream DNS"
-else
-    echo "  5. Pi-hole: upstream DNS"
 fi
 
 # Cleanup

--- a/scripts/configure-apps.sh
+++ b/scripts/configure-apps.sh
@@ -496,16 +496,16 @@ configure_pihole() {
 
     # Check current upstream DNS configuration
     local current_dns
-    current_dns=$(docker exec pihole pihole-FTL --config dns.upstreams -q 2>/dev/null || true)
-    
+    current_dns=$(docker exec pihole pihole-FTL --config dns.upstreams 2>/dev/null || true)
+
     if [[ "$current_dns" == *"172.20.0.6#5053"* ]]; then
         skip "Pi-hole: upstream DNS (already using dnscrypt-proxy)"
     else
         # Set dnscrypt-proxy as upstream DNS using FTL config
         if docker exec pihole pihole-FTL --config dns.upstreams '["172.20.0.6#5053"]' >/dev/null 2>&1; then
             ok "Pi-hole: set upstream DNS to dnscrypt-proxy (172.20.0.6#5053)"
-            # Restart DNS service to apply changes
-            docker exec pihole pihole restartdns >/dev/null 2>&1
+            # Restart container to apply — pihole restartdns fails with cap_drop: ALL
+            docker restart pihole >/dev/null 2>&1
         else
             fail "Pi-hole: set upstream DNS"
         fi


### PR DESCRIPTION
This pull request introduces a new DNS privacy layer to the stack by adding a `dnscrypt-proxy` service, which encrypts DNS queries and is used as the upstream DNS for Pi-hole. It also updates the automated configuration script to set up Pi-hole to use this new service, ensuring DNS traffic is encrypted by default. The changes improve security, automate previously manual steps, and update documentation accordingly.

**DNS Privacy and Service Integration:**

* Added a new `dnscrypt-proxy` service to `docker-compose.arr-stack.yml`, including configuration for network, ports, capabilities, health checks, and a dedicated volume (`dnscrypt-config`). This service handles encrypted DNS queries and is used internally by Pi-hole.
* Updated the `volumes` section in `docker-compose.arr-stack.yml` to include `dnscrypt-config` for persistent configuration of the new DNS service.
* Modified the Pi-hole service definition to depend on the health of `dnscrypt-proxy` and added documentation for configuring Pi-hole to use `dnscrypt-proxy` as its upstream DNS.

**Automation and Documentation Updates:**

* Enhanced `scripts/configure-apps.sh` to automatically configure Pi-hole's upstream DNS to point to `dnscrypt-proxy` (172.20.0.6#5053), including a new `configure_pihole` function and integration into the main setup flow. [[1]](diffhunk://#diff-71a3aee6a960931b30ff29efe21f95f064c01b29a76fb53d2d0d5eac0e03684cR485-R514) [[2]](diffhunk://#diff-71a3aee6a960931b30ff29efe21f95f064c01b29a76fb53d2d0d5eac0e03684cR530-R531)
* Updated comments and summary output in `scripts/configure-apps.sh` to reflect Pi-hole's new automated DNS configuration step, and revised the documentation to include Pi-hole in the list of automatically configured apps. [[1]](diffhunk://#diff-71a3aee6a960931b30ff29efe21f95f064c01b29a76fb53d2d0d5eac0e03684cL5-R5) [[2]](diffhunk://#diff-71a3aee6a960931b30ff29efe21f95f064c01b29a76fb53d2d0d5eac0e03684cL30) [[3]](diffhunk://#diff-71a3aee6a960931b30ff29efe21f95f064c01b29a76fb53d2d0d5eac0e03684cL524-L526)