### PR TITLE
feat: add Kavita (reading server) and Suwayomi (manga downloader)

### DIFF
--- a/.claude/config.local.md.example
+++ b/.claude/config.local.md.example
@@ -36,6 +36,8 @@ Copy this file to `config.local.md` and fill in your values.
 | Cloudflared | 172.20.0.12 |
 | Uptime Kuma | 172.20.0.13 |
 | duc | 172.20.0.14 |
+| Kavita | 172.20.0.17 |
+| Suwayomi | (via Gluetun, 172.20.0.3:4567) |
 
 ## Service URLs
 
@@ -67,6 +69,8 @@ NAS LAN IP: `YOUR_NAS_LAN_IP` (or `your-nas.local`)
 | Radarr | http://your-nas.local:7878 |
 | Prowlarr | http://your-nas.local:9696 |
 | qBittorrent | http://your-nas.local:8085 |
+| Kavita | http://your-nas.local:5000 |
+| Suwayomi | http://your-nas.local:4567 |
 
 ## VPN
 
@@ -81,6 +85,6 @@ NAS LAN IP: `YOUR_NAS_LAN_IP` (or `your-nas.local`)
 | Path | Contents |
 |------|----------|
 | `/volume1/docker/arr-stack/` | Docker compose files and configs |
-| `/volume1/data/media/` | Media library (movies, tv) |
+| `/volume1/data/media/` | Media library (movies, tv, books, manga) |
 | `/volume1/data/torrents/` | qBittorrent downloads |
 | `/volume1/data/usenet/` | SABnzbd downloads |

--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -20,3 +20,6 @@ RADARR_USERNAME=your_radarr_username
 RADARR_PASSWORD=your_radarr_password
 PROWLARR_USERNAME=your_prowlarr_username
 PROWLARR_PASSWORD=your_prowlarr_password
+KAVITA_USERNAME=your_kavita_username
+KAVITA_PASSWORD=your_kavita_password
+# Suwayomi needs no credentials — AUTH_MODE defaults to none

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+> **Not yet verified on the NAS.** Per CLAUDE.md this must be deployed from the
+> `feat/kavita-suwayomi` branch and confirmed working before it reaches `main`.
+
+### Added
+- **Kavita** (`lscr.io/linuxserver/kavita:0.9.0`) — reading server for comics, manga and ebooks. Bridge service on `172.20.0.17:5000`, **not** behind the VPN: like Jellyfin it only ever serves files already on disk. Libraries are mounted read-only (`/data/media/books`, `/data/media/manga`) because Kavita keeps covers, reading progress and bookmarks in its `/config` volume and writes nothing to the media tree. Uses the existing `x-security-lsio` anchor. Healthcheck hits `/api/health`, which is anonymous.
+- **Suwayomi** (`ghcr.io/suwayomi/suwayomi-server:v2.3.2243`) — manga library manager and downloader. Runs **behind Gluetun** (`network_mode: service:gluetun`, port `4567` published on gluetun, `gluetun.dependent=true` so `gluetun-recover` revives it after a VPN flap). It scrapes public scanlation sources directly, which is the same traffic class as Prowlarr's indexer scraping, so it gets the same protection. Being in gluetun's namespace also means it reaches **FlareSolverr on `localhost:8191`** exactly as Prowlarr does.
+- **`kavita.lan` and `suwayomi.lan`** — Traefik routers plus dnsmasq entries. Suwayomi routes to `172.20.0.3:4567` (gluetun's IP) since it has no IP of its own.
+- **Four new E2E tests** (14 → 18): UI screenshots for both, a Kavita assertion that its libraries live under `/data/media`, and a Suwayomi GraphQL `aboutServer` check that doubles as proof gluetun is publishing 4567.
+
+### Changed
+- **`MEDIA_ROOT/media` gains `books/` and `manga/`.** SETUP.md's `mkdir` commands now create them. **Existing installs must create them by hand before deploying** — if Docker auto-creates the bind-mount targets they land as `root:root` and Suwayomi, which runs as `PUID:PGID`, cannot write:
+  ```bash
+  sudo mkdir -p /volume1/data/media/{books,manga}
+  sudo chown -R 1000:1000 /volume1/data/media/books /volume1/data/media/manga
+  ```
+- **`scripts/arr-backup.sh`** now backs up `kavita-config` and `suwayomi-config`. Both hold state that no re-scan can rebuild: Kavita's users and reading progress, Suwayomi's tracked series and installed extensions.
+
+### Notes on the two non-obvious config choices
+- **`DOWNLOAD_AS_CBZ=true`** is not cosmetic. Suwayomi's default writes each chapter as a folder of loose images, which Kavita does not recognise as a series at all — the manga library would scan to empty.
+- **`KCEF_ENABLED=false`.** Suwayomi bundles a Chromium (KCEF) as a fallback WebView. Its sandbox needs privileges this stack drops (`no-new-privileges` + `cap_drop: ALL`), and a failed KCEF download is a known upstream startup hang. FlareSolverr covers the challenge-solving those sources need, so it is off deliberately.
+- **Downloads are mounted, not configured.** Upstream does not expose the downloads path as an env var — it expects a bind mount, and the mount must be listed *before* the config volume or it is ignored. Chapters land at `MEDIA_ROOT/media/manga/mangas/<Source>/<Series>/<Chapter>.cbz`, so Kavita's manga library folders are the per-source directories (`/data/media/manga/mangas/<Source>`), not the top of the tree — Kavita treats each immediate subfolder of a library root as a series.
+
 ## [1.7.26] - 2026-08-05
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,4 +39,4 @@ Back up a service's config volume before any version bump with a DB migration (`
 
 ## E2E Tests
 
-Run `npm run test:e2e` after any change to Docker Compose files, service config, networks, or ports. All 14 tests must pass. They screenshot every service UI and verify API responses.
+Run `npm run test:e2e` after any change to Docker Compose files, service config, networks, or ports. All 18 tests must pass. They screenshot every service UI and verify API responses.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,7 +236,7 @@ Every version-changing release follows this order. Doing it as one unbroken flow
    ```bash
    npm run test:e2e
    ```
-   This logs into each service, takes screenshots of every dashboard, and asserts root folders and media libraries are present. All 14 tests must pass. Screenshots are saved to `tests/e2e/screenshots/` for visual review.
+   This logs into each service, takes screenshots of every dashboard, and asserts root folders and media libraries are present. All 18 tests must pass. Screenshots are saved to `tests/e2e/screenshots/` for visual review.
 
 ### Tagging and Publishing
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Works on Ugreen, Synology, QNAP, or any Docker host.
 - **Production-ready** — Real healthchecks, auto-recovery when VPN reconnects, backup script. Not just "it runs."
 - **Battle-tested** — Edge cases found and fixed across multiple NAS setups. More resilient than most.
 - **Best practices built in** — Downloads appear instantly without using extra disk space, files are named consistently, and download settings are tuned for security and performance. Based on [TRaSH Guides](https://trash-guides.info/).
-- **Everything you need** — Jellyfin, Sonarr, Radarr, Prowlarr, Bazarr, Seerr, qBittorrent, SABnzbd, Pi-hole, Cloudflare Tunnel, Tailscale. Modular — skip what you don't need, add what you do (e.g. Lidarr).
+- **Everything you need** — Jellyfin, Sonarr, Radarr, Prowlarr, Bazarr, Seerr, qBittorrent, SABnzbd, Kavita, Suwayomi, Pi-hole, Cloudflare Tunnel, Tailscale. Modular — skip what you don't need, add what you do (e.g. Lidarr).
 - **Step-by-step guide** — Not just a docker-compose file in a repo.
 - **Flexible** — Supports 30+ VPN providers. Plex users can swap or add Jellyfin (see [Plex guide](docs/SETUP.md#plex)).
 - **Privacy by default** — All downloads route through your VPN.
@@ -42,6 +42,8 @@ Works on Ugreen, Synology, QNAP, or any Docker host.
 Request: Seerr → Sonarr/Radarr → Prowlarr
 Download: qBittorrent (torrents) or SABnzbd (Usenet) — both via VPN (Gluetun)
 Watch: Jellyfin — locally or remotely via Traefik
+
+**And for reading:** Suwayomi tracks and downloads manga (also via VPN) → Kavita serves it, plus your comics and ebooks, to any browser or OPDS reader.
 
 **Choose your setup:**
 | Setup | How you access | What you need |

--- a/docker-compose.arr-stack.yml
+++ b/docker-compose.arr-stack.yml
@@ -19,6 +19,8 @@ volumes:
   radarr-config:
   jellyfin-config:
   jellyfin-cache:
+  kavita-config:
+  suwayomi-config:
   seerr-config:
   bazarr-config:
   dnscrypt-config:
@@ -113,6 +115,7 @@ services:
       - "8085:8085"   # qBittorrent
       - "8082:8080"   # SABnzbd
       - "8191:8191"   # FlareSolverr
+      - "4567:4567"   # Suwayomi
     networks:
       arr-stack:
         ipv4_address: 172.20.0.3
@@ -330,6 +333,110 @@ services:
       timeout: 30s
       retries: 2
       start_period: 30s
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # KAVITA - Reading server for comics, manga and ebooks. The Jellyfin of the
+  # bookshelf: it only serves files that are already on disk.
+  # Access: kavita.lan | NAS_IP:5000
+  # Runs on the arr-stack bridge (own IP 172.20.0.17), NOT behind the VPN —
+  # same rationale as Jellyfin: it never talks to indexers or peers.
+  # Libraries are mounted read-only; Kavita writes nothing to the media tree
+  # (covers, reading progress and bookmarks all live in /config).
+  #   /data/media/books              → Books library
+  #   /data/media/manga/mangas/<Src> → Manga library (filled by Suwayomi below)
+  # ═══════════════════════════════════════════════════════════════════════════
+  kavita:
+    image: lscr.io/linuxserver/kavita:0.9.0
+    container_name: kavita
+    <<: *lsio-security
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - TZ=${TZ}
+    ports:
+      # Synology users: DSM owns host port 5000 — remap the host side (e.g. "5002:5000")
+      - "5000:5000"   # Direct local access (http://NAS_IP:5000)
+    networks:
+      arr-stack:
+        ipv4_address: 172.20.0.17
+    volumes:
+      - kavita-config:/config
+      - ${MEDIA_ROOT}/media/books:/data/media/books:ro
+      - ${MEDIA_ROOT}/media/manga:/data/media/manga:ro
+    labels:
+      - deunhealth.restart.on.unhealthy=true
+    restart: always
+    logging: *default-logging
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:5000/api/health"]
+      interval: 2m
+      timeout: 15s
+      retries: 3
+      start_period: 60s
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # SUWAYOMI - Manga library manager + downloader (the Sonarr/Radarr of manga).
+  # Tracks series from scanlation sources and downloads new chapters.
+  # Access: suwayomi.lan | NAS_IP:4567
+  #
+  # Runs behind the VPN (network_mode: service:gluetun) because it scrapes
+  # public manga sources directly — same traffic class as Prowlarr's indexer
+  # scraping, so it gets the same protection. Two consequences:
+  #   - Its port is published on gluetun above, not here.
+  #   - It reaches FlareSolverr on localhost:8191, exactly like Prowlarr does.
+  #
+  # Downloads land in the media tree (not the config volume) so Kavita can read
+  # them: ${MEDIA_ROOT}/media/manga/mangas/<Source>/<Title>/<Chapter>.cbz
+  # The downloads path is NOT configurable via env — upstream mounts it instead,
+  # and the mount MUST be listed before the config volume. See:
+  # https://github.com/Suwayomi/docker-tachidesk#downloads-folder
+  # ═══════════════════════════════════════════════════════════════════════════
+  suwayomi:
+    image: ghcr.io/suwayomi/suwayomi-server:v2.3.2243
+    container_name: suwayomi
+    <<: *default-security
+    # Image runs as its own `suwayomi` user (uid 1000) but chmods its tree 777,
+    # so it honours an arbitrary uid:gid. Match the rest of the stack so the
+    # downloads bind-mount is written with the same ownership as other media.
+    user: "${PUID}:${PGID}"
+    network_mode: "service:gluetun"
+    depends_on:
+      gluetun:
+        condition: service_healthy
+        restart: true
+    environment:
+      - TZ=${TZ}
+      # CBZ is what Kavita reads natively — without this, chapters are written
+      # as loose image folders and Kavita sees no series.
+      - DOWNLOAD_AS_CBZ=true
+      # Shares gluetun's namespace with FlareSolverr, so localhost reaches it.
+      - FLARESOLVERR_ENABLED=true
+      - FLARESOLVERR_URL=http://localhost:8191
+      # KCEF is a bundled Chromium used as a fallback WebView. Its sandbox needs
+      # privileges this stack drops (no-new-privileges + cap_drop ALL), and a
+      # failed KCEF download is a known startup hang upstream. FlareSolverr
+      # above covers the challenge-solving case, so keep it off.
+      - KCEF_ENABLED=false
+    volumes:
+      # ORDER MATTERS: downloads before the config volume, or the bind is ignored.
+      - ${MEDIA_ROOT}/media/manga:/home/suwayomi/.local/share/Tachidesk/downloads
+      - suwayomi-config:/home/suwayomi/.local/share/Tachidesk
+    labels:
+      - deunhealth.restart.on.unhealthy=true
+      - gluetun.dependent=true  # gluetun-recover restarts this if SIGKILLed by a gluetun restart
+    restart: always
+    logging: *default-logging
+    healthcheck:
+      # Query the GraphQL API rather than "/" — the web UI is downloaded at
+      # first boot and served separately, so "/" can 404 while the server is
+      # fine. aboutServer needs no auth.
+      test: ["CMD", "curl", "-sf", "-X", "POST", "-H", "Content-Type: application/json",
+             "-d", "{\"query\":\"{aboutServer{name}}\"}",
+             "http://localhost:4567/api/graphql"]
+      interval: 3m
+      timeout: 15s
+      retries: 3
+      start_period: 120s  # JVM start + first-run web UI download
 
 # ═══════════════════════════════════════════════════════════════════════════
   # DNSCRYPT-PROXY - DNS over HTTPS/DNSCrypt proxy. Encrypts DNS queries.

--- a/docs/APP-CONFIG.md
+++ b/docs/APP-CONFIG.md
@@ -13,6 +13,8 @@ Your stack is running! Now configure each app to work together.
 6. Seerr (requests — needs Jellyfin + Sonarr/Radarr configured first)
 7. Bazarr (subtitles — needs Sonarr/Radarr configured first)
 8. Pi-hole (DNS — independent, do anytime)
+9. Suwayomi (manga downloads — independent, needed before Kavita's manga library)
+10. Kavita (reading server — reads what Suwayomi downloads)
 
 See **[Quick Reference → Service Connection Guide](REFERENCE.md#service-connection-guide)** for how services connect to each other.
 
@@ -306,6 +308,48 @@ Automatically downloads subtitles for your media.
 **Optional:** Set your router's DHCP DNS to your NAS IP for network-wide ad-blocking.
 
 > **Warning:** If your NAS goes down, every device on your network will lose internet (DNS stops resolving). To recover: temporarily change your device's DNS to `1.1.1.1` (or enable a VPN) so you can access your router and revert the DHCP DNS setting until Pi-hole is back up.
+
+## 4.10 Suwayomi (Manga Downloads)
+
+The Sonarr/Radarr of manga: tracks series from scanlation sources and downloads new chapters. Runs behind the VPN, so configure it before Kavita — Kavita reads what this writes.
+
+1. **Access:** `http://NAS_IP:4567`
+2. **Install sources:** Browse → Extensions → install the source extensions you want
+3. **Add series:** Browse → pick a source → search → open a series → **Add to library**
+4. **Turn on auto-download:** Settings → Downloads → enable **Auto download new chapters**
+5. **Set a login (recommended):** Suwayomi ships with `AUTH_MODE=none`. To require one, add to the `suwayomi` service in `docker-compose.arr-stack.yml`:
+   ```yaml
+   - AUTH_MODE=simple_login
+   - AUTH_USERNAME=your_username
+   - AUTH_PASSWORD=your_password
+   ```
+
+**Already configured for you in compose** — don't change these:
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| `DOWNLOAD_AS_CBZ` | `true` | Kavita reads `.cbz`; loose image folders show up as no series at all |
+| `FLARESOLVERR_URL` | `http://localhost:8191` | Shares Gluetun's namespace with FlareSolverr, same as Prowlarr |
+| `KCEF_ENABLED` | `false` | The bundled Chromium can't sandbox under this stack's hardening — FlareSolverr covers it |
+
+> **Where files land:** `MEDIA_ROOT/media/manga/mangas/<Source>/<Series>/<Chapter>.cbz`. The downloads path isn't configurable via env — upstream expects it to be mounted, which compose already does.
+
+## 4.11 Kavita (Reading Server)
+
+Serves comics, manga and ebooks to any browser, tablet, or OPDS reader.
+
+1. **Access:** `http://NAS_IP:5000` *(Synology: DSM owns port 5000 — remap the host side in compose first)*
+2. **Create the admin account:** first load prompts for it. There is no default login.
+3. **Add a Manga library:** Libraries → Add Library → Type **Manga** → add one folder per Suwayomi source:
+   `/data/media/manga/mangas/<SourceName>`
+
+   > **Why not just `/data/media/manga`?** Kavita treats each immediate subfolder of a library root as a series. Point it at the top and you get one "series" called `mangas`. Pointing it at the per-source folder makes each manga a series, correctly.
+
+4. **Add a Books library:** Libraries → Add Library → Type **Book** → folder `/data/media/books`
+5. **Scan:** Libraries → ⋮ → Scan Library
+6. **Read on a tablet:** Settings → Users → your user → copy the OPDS URL into Panels, Chunky, KOReader, etc.
+
+> **Libraries are mounted read-only.** Kavita never writes to the media tree — covers, reading progress and bookmarks all live in its `/config` volume. If you need Kavita to write (e.g. metadata files), drop the `:ro` from its volume lines in `docker-compose.arr-stack.yml`.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,6 +28,27 @@ When someone requests a movie or TV show, here's what happens:
 
 > **Why both qBittorrent and SABnzbd?** Torrents are free but can be slow/unreliable. Usenet costs ~$5/month but is faster, more reliable, and has no ratio requirements. Most users configure both - Sonarr/Radarr will try Usenet first, fall back to torrents.
 
+## The Reading Flow
+
+Comics, manga and ebooks follow the same shape with two services instead of five:
+
+```
+┌──────────────┐     ┌──────────────────────────┐     ┌──────────┐
+│  Suwayomi    │────▶│  MEDIA_ROOT/media/manga  │────▶│  Kavita  │
+│ (track +     │     │  mangas/<Src>/<Title>/   │     │  (read)  │
+│  download)   │     │  <Chapter>.cbz           │     │          │
+└──────────────┘     └──────────────────────────┘     └──────────┘
+       │
+  Through VPN (Gluetun)                                Not through VPN
+```
+
+1. **Suwayomi** — install source extensions, track series, download new chapters as `.cbz`
+2. **Kavita** — scans that folder and serves it to browsers, tablets and OPDS readers
+
+Ebooks skip step 1 entirely: drop `.epub`/`.pdf` files into `MEDIA_ROOT/media/books` and Kavita picks them up.
+
+> **Why is Suwayomi behind the VPN but Kavita isn't?** Suwayomi scrapes public scanlation sources — the same traffic class as Prowlarr's indexer scraping. Kavita only ever reads files that are already on your disk, exactly like Jellyfin.
+
 ## VPN Protection
 
 **Why VPN?** Your ISP can see BitTorrent traffic. The VPN encrypts this so they only see "encrypted traffic to VPN server".
@@ -35,32 +56,32 @@ When someone requests a movie or TV show, here's what happens:
 **Why not everything through VPN?** Streaming from Jellyfin doesn't need protection (you're watching your own files) and VPN would slow it down.
 
 ```
-                              ┌─────────────────────────────────────────┐
-                              │            GLUETUN (VPN)                │
-                              │                                         │
-Internet ◄───VPN Tunnel───────│  qBit   SABnzbd   Prowlarr   Flare      │
-                              │    ▲        ▲         ▲        ▲        │
-                              │    │        │         │        │        │
-                              │    └────────┴─────────┴────────┘        │
-                              │         All share localhost             │
-                              └─────────────────────────────────────────┘
+                              ┌──────────────────────────────────────────────┐
+                              │              GLUETUN (VPN)                   │
+                              │                                              │
+Internet ◄───VPN Tunnel───────│  qBit  SABnzbd  Prowlarr  Flare  Suwayomi   │
+                              │    ▲       ▲        ▲       ▲        ▲       │
+                              │    │       │        │       │        │       │
+                              │    └───────┴────────┴───────┴────────┘       │
+                              │            All share localhost               │
+                              └──────────────────────────────────────────────┘
                                                  │
                                     ─ ─ ─ ─ ─ ─ ─│─ ─ ─ ─ ─ ─ ─
                                                  │
-                              ┌──────────────────┴──────────────────────┐
-Internet ◄──Cloudflare Tunnel─│  Jellyfin    Seerr                     │
-  (remote)                    │  (stream)    (requests)                 │
-                              │                                         │
-LAN only ◄────────────────────│  Pi-hole   Sonarr    Radarr   Bazarr   │
-  (local)                     │  (DNS)     (manage)  (manage)  (subs)   │
-                              └─────────────────────────────────────────┘
+                              ┌──────────────────┴───────────────────────────┐
+Internet ◄──Cloudflare Tunnel─│  Jellyfin    Seerr                           │
+  (remote)                    │  (stream)    (requests)                      │
+                              │                                              │
+LAN only ◄────────────────────│  Pi-hole  Sonarr   Radarr   Bazarr  Kavita   │
+  (local)                     │  (DNS)    (manage) (manage) (subs)  (read)   │
+                              └──────────────────────────────────────────────┘
 ```
 
 > **Note:** Download services go through VPN to hide torrent traffic from your ISP. Streaming services don't need VPN protection. Remote access uses Cloudflare Tunnel (not VPN) - see [Access Levels](#access-levels).
 
 ## Service Connections
 
-Services behind Gluetun (qBittorrent, SABnzbd, Prowlarr, FlareSolverr) use `localhost` to talk to each other. Crossing the bridge↔VPN boundary needs care — the VPN namespace's DNS is Pi-hole, which can't resolve Docker container names, so VPN-side services must reach bridge services by **IP**.
+Services behind Gluetun (qBittorrent, SABnzbd, Prowlarr, FlareSolverr, Suwayomi) use `localhost` to talk to each other. Crossing the bridge↔VPN boundary needs care — the VPN namespace's DNS is Pi-hole, which can't resolve Docker container names, so VPN-side services must reach bridge services by **IP**.
 
 ```
 Bridge → VPN-side (use gluetun):     VPN-side → bridge (use IP):
@@ -74,7 +95,14 @@ Bridge → bridge (use name):          Behind-VPN → behind-VPN (localhost):
 ─────────────────────────────        ──────────────────────────
 Seerr/Bazarr → Sonarr                Prowlarr → FlareSolverr
   └── sonarr:8989 / radarr:7878        └── localhost:8191
+                                     Suwayomi → FlareSolverr
+                                       └── localhost:8191
 ```
+
+**Kavita ↔ Suwayomi is the one pair that doesn't talk over the network at all.**
+Suwayomi writes `.cbz` chapters into `MEDIA_ROOT/media/manga/mangas/<Source>/<Title>/`
+and Kavita mounts that same tree read-only. Suwayomi downloads, Kavita reads —
+the handoff is the filesystem, exactly like Sonarr → Jellyfin.
 
 ## Network Layout
 
@@ -87,6 +115,7 @@ arr-stack network (172.20.0.0/24)
 ├──────────────┼──────────────┼────────────────────────────────┼──────────────────│
 │ 172.20.0.3   │ Gluetun      │ VPN gateway (qBit/SAB/Prowlarr)│ Core             │
 │ 172.20.0.4   │ Jellyfin     │ Media server                   │ Core             │
+│ 172.20.0.17  │ Kavita       │ Comic/manga/ebook reader       │ Core             │
 │ 172.20.0.8   │ Seerr        │ Request portal                 │ Core             │
 │ 172.20.0.9   │ Bazarr       │ Subtitles                      │ Core             │
 │ 172.20.0.10  │ Sonarr       │ TV manager (bridge, not VPN)   │ Core             │
@@ -101,6 +130,9 @@ arr-stack network (172.20.0.0/24)
 │ 172.20.0.16  │ DIUN         │ Image update notifier          │ Optional         │
 ───────────────────────────────────────────────────────────────────────────────────
 ```
+
+> **Suwayomi** has no IP of its own — it runs in Gluetun's network namespace, so it
+> answers on `172.20.0.3:4567` like the other VPN-side services.
 
 ## Access Levels
 
@@ -165,9 +197,11 @@ Two YAML anchors define security profiles in each compose file:
 | Anchor | Used by | Capabilities |
 |--------|---------|-------------|
 | `x-security` | All non-LSIO services | None by default (services add back only what they need) |
-| `x-security-lsio` | Sonarr, Radarr, Prowlarr, qBittorrent, SABnzbd, Bazarr | `CHOWN`, `SETUID`, `SETGID`, `DAC_OVERRIDE` (s6-overlay needs these to switch users during init) |
+| `x-security-lsio` | Sonarr, Radarr, Prowlarr, qBittorrent, SABnzbd, Bazarr, Kavita | `CHOWN`, `SETUID`, `SETGID`, `DAC_OVERRIDE` (s6-overlay needs these to switch users during init) |
 
 Services that write to Docker volumes as root add back `CHOWN` + `DAC_OVERRIDE` (Jellyfin, Seerr, Uptime Kuma, DUC, Beszel, DIUN, Configarr). Services with read-only or no volumes don't need any (FlareSolverr, Cloudflared, Traefik, Deunhealth, Beszel-agent).
+
+**Suwayomi** needs no capabilities at all: it already runs as a non-root user in its image, and this stack pins that user to `PUID:PGID` so it never has to switch. The trade-off is that its bundled Chromium WebView (KCEF) can't sandbox itself under `no-new-privileges`, so `KCEF_ENABLED=false` — FlareSolverr covers the challenge-solving those sources would otherwise need.
 
 Additional requirements:
 - **Gluetun** — adds `NET_ADMIN` (required to create VPN tunnel interfaces)

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -16,11 +16,13 @@
 | Service | Core (IP:port) | + local DNS | + remote access |
 |---------|----------------|-------------|-----------------|
 | Jellyfin | `NAS_IP:8096` | `http://jellyfin.lan` | `https://jellyfin.DOMAIN` |
+| Kavita | `NAS_IP:5000` | `http://kavita.lan` | — |
 | Seerr | `NAS_IP:5055` | `http://seerr.lan` | `https://seerr.DOMAIN` |
 | Sonarr | `NAS_IP:8989` | `http://sonarr.lan` | — |
 | Radarr | `NAS_IP:7878` | `http://radarr.lan` | — |
 | Prowlarr | `NAS_IP:9696` | `http://prowlarr.lan` | — |
 | Bazarr | `NAS_IP:6767` | `http://bazarr.lan` | — |
+| Suwayomi | `NAS_IP:4567` | `http://suwayomi.lan` | — |
 | qBittorrent | `NAS_IP:8085` | `http://qbit.lan` | — |
 | SABnzbd | `NAS_IP:8082` | `http://sabnzbd.lan` | — |
 | Pi-hole | `NAS_IP:8081/admin` | `http://pihole.lan/admin` | — |
@@ -42,9 +44,11 @@
 | ↳ qBittorrent | (via Gluetun) | 8085 | Torrent downloads |
 | ↳ SABnzbd | (via Gluetun) | 8082 | Usenet downloads |
 | ↳ Prowlarr | (via Gluetun) | 9696 | Indexer manager |
+| ↳ Suwayomi | (via Gluetun) | 4567 | Manga library + downloader |
 | Sonarr | 172.20.0.10 | 8989 | TV shows (own IP — not via VPN) |
 | Radarr | 172.20.0.11 | 7878 | Movies (own IP — not via VPN) |
 | Jellyfin | 172.20.0.4 | 8096 | Media server |
+| Kavita | 172.20.0.17 | 5000 | Comics/manga/ebook reader |
 | Pi-hole | 172.20.0.5 | 8081 | DNS ad-blocking (`/admin`) |
 | Seerr | 172.20.0.8 | 5055 | Request management |
 | Bazarr | 172.20.0.9 | 6767 | Subtitles |
@@ -80,9 +84,9 @@
 
 ### Service Connection Guide
 
-**VPN-protected services** (qBittorrent, SABnzbd, Prowlarr, FlareSolverr) share Gluetun's network via `network_mode: service:gluetun` — these carry the traffic that must stay hidden (peers + indexer scraping).
+**VPN-protected services** (qBittorrent, SABnzbd, Prowlarr, FlareSolverr, Suwayomi) share Gluetun's network via `network_mode: service:gluetun` — these carry the traffic that must stay hidden (peers + indexer/source scraping).
 
-**Bridge services** (Sonarr, Radarr, Jellyfin, Seerr, Bazarr, …) run on the `arr-stack` bridge with their own IPs. Sonarr (172.20.0.10) and Radarr (172.20.0.11) are *not* behind the VPN: they only contact metadata providers (TVDB/TMDB) and internal services, so they need no VPN — and staying on the bridge keeps them reachable when a gluetun/VPN reconnect happens.
+**Bridge services** (Sonarr, Radarr, Jellyfin, Kavita, Seerr, Bazarr, …) run on the `arr-stack` bridge with their own IPs. Sonarr (172.20.0.10) and Radarr (172.20.0.11) are *not* behind the VPN: they only contact metadata providers (TVDB/TMDB) and internal services, so they need no VPN — and staying on the bridge keeps them reachable when a gluetun/VPN reconnect happens.
 
 | From | To | Use | Why |
 |------|-----|-----|-----|
@@ -98,6 +102,8 @@
 | Seerr | Jellyfin | `jellyfin:8096` | Both have own IPs |
 | Bazarr | Sonarr | `sonarr:8989` | Both on the bridge |
 | Bazarr | Radarr | `radarr:7878` | Both on the bridge |
+| Suwayomi | FlareSolverr | `localhost:8191` | Same network stack (both behind Gluetun) |
+| Kavita | Suwayomi | (filesystem) | Kavita reads the `.cbz` files Suwayomi writes — no HTTP between them |
 
 > **Reaching VPN-side services from the bridge:** use the `gluetun` hostname (or `172.20.0.3`) — qBittorrent/SABnzbd/Prowlarr listen inside gluetun's namespace, so they have no Docker DNS name of their own. Gluetun's `FIREWALL_OUTBOUND_SUBNETS` includes `172.20.0.0/24`, so Prowlarr (in the VPN namespace) can reach Sonarr/Radarr on the bridge.
 
@@ -160,12 +166,14 @@ Services start in dependency order (handled automatically by `depends_on`):
 | Service | Description |
 |---------|-------------|
 | Jellyfin | Media streaming |
+| Kavita | Comic/manga/ebook reading server |
 | Seerr | Request system |
 | Sonarr | TV management |
 | Radarr | Movie management |
 | Prowlarr | Indexer manager |
 | qBittorrent | Torrent client |
 | SABnzbd | Usenet client |
+| Suwayomi | Manga library + downloader |
 | Bazarr | Subtitles |
 | Gluetun | VPN gateway |
 | Pi-hole | DNS/ad-blocking |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -202,7 +202,7 @@ ssh your-username@nas-ip
 sudo apt-get update && sudo apt-get install -y git
 
 # Create media and download directories
-sudo mkdir -p /volume1/data/media/{tv,movies}
+sudo mkdir -p /volume1/data/media/{tv,movies,books,manga}
 sudo mkdir -p /volume1/data/torrents/{tv,movies}
 sudo mkdir -p /volume1/data/usenet/{incomplete,complete/{tv,movies}}
 sudo chown -R 1000:1000 /volume1/data/media /volume1/data/torrents /volume1/data/usenet
@@ -239,7 +239,7 @@ Scanning media files for viruses is unnecessary - video/audio files can't contai
 <summary><strong>Synology / QNAP</strong></summary>
 
 Use File Station to create:
-- **data** shared folder with subfolder: **media** (containing **tv** and **movies**)
+- **data** shared folder with subfolder: **media** (containing **tv**, **movies**, **books** and **manga**)
 - **docker** shared folder
 
 Then via SSH:
@@ -250,7 +250,7 @@ ssh your-username@nas-ip
 sudo synopkg install Git
 
 # Create media and download directories
-sudo mkdir -p /volume1/data/media/{tv,movies}
+sudo mkdir -p /volume1/data/media/{tv,movies,books,manga}
 sudo mkdir -p /volume1/data/torrents/{tv,movies}
 sudo mkdir -p /volume1/data/usenet/{incomplete,complete/{tv,movies}}
 sudo chown -R 1000:1000 /volume1/data/media /volume1/data/torrents /volume1/data/usenet
@@ -276,7 +276,7 @@ sudo chown -R 1000:1000 "$NAS_STACK_DIR"
 sudo apt-get update && sudo apt-get install -y git
 
 # Create media and download directories
-sudo mkdir -p /srv/data/media/{tv,movies}
+sudo mkdir -p /srv/data/media/{tv,movies,books,manga}
 sudo mkdir -p /srv/data/torrents/{tv,movies}
 sudo mkdir -p /srv/data/usenet/{incomplete,complete/{tv,movies}}
 sudo chown -R 1000:1000 /srv/data

--- a/pihole/dnsmasq.d/02-local-dns.conf.example
+++ b/pihole/dnsmasq.d/02-local-dns.conf.example
@@ -11,6 +11,7 @@
 
 # Media services
 address=/jellyfin.lan/TRAEFIK_LAN_IP
+address=/kavita.lan/TRAEFIK_LAN_IP
 address=/seerr.lan/TRAEFIK_LAN_IP
 address=/jellyseerr.lan/TRAEFIK_LAN_IP
 address=/jellyseer.lan/TRAEFIK_LAN_IP
@@ -20,6 +21,7 @@ address=/sonarr.lan/TRAEFIK_LAN_IP
 address=/radarr.lan/TRAEFIK_LAN_IP
 address=/prowlarr.lan/TRAEFIK_LAN_IP
 address=/bazarr.lan/TRAEFIK_LAN_IP
+address=/suwayomi.lan/TRAEFIK_LAN_IP
 
 # Download clients
 address=/qbit.lan/TRAEFIK_LAN_IP

--- a/scripts/arr-backup.sh
+++ b/scripts/arr-backup.sh
@@ -199,6 +199,8 @@ VOLUME_SUFFIXES=(
   prowlarr-config         # Indexer configs and API keys
   bazarr-config           # Subtitle provider credentials
   uptime-kuma-data        # Monitor configurations
+  kavita-config           # Users, libraries, reading progress (not re-scannable)
+  suwayomi-config         # Tracked series, installed extensions, reading progress
 )
 
 # Request manager - detect which volume exists

--- a/scripts/lib/check-domains.sh
+++ b/scripts/lib/check-domains.sh
@@ -35,12 +35,14 @@ check_domains() {
     # .lan domains to check (via Pi-hole DNS)
     local lan_domains=(
         "jellyfin.lan"
+        "kavita.lan"
         "seerr.lan"
         "jellyseerr.lan"
         "sonarr.lan"
         "radarr.lan"
         "prowlarr.lan"
         "bazarr.lan"
+        "suwayomi.lan"
         "qbit.lan"
         "sabnzbd.lan"
         "traefik.lan"

--- a/scripts/lib/check-uptime-monitors.sh
+++ b/scripts/lib/check-uptime-monitors.sh
@@ -13,12 +13,14 @@ check_uptime_monitors() {
         "duc"
         "FlareSolverr"
         "Jellyfin"
+        "Kavita"
         "Seerr"
         "Pi-hole"
         "Prowlarr"
         "qBittorrent"
         "Radarr"
         "Sonarr"
+        "Suwayomi"
         "Traefik"
     )
 

--- a/tests/e2e/stack.spec.ts
+++ b/tests/e2e/stack.spec.ts
@@ -12,6 +12,7 @@ function screenshotPath(name: string) {
 
 const PORTS = {
   jellyfin: 8096,
+  kavita: 5000,
   sonarr: 8989,
   radarr: 7878,
   prowlarr: 9696,
@@ -19,6 +20,7 @@ const PORTS = {
   sabnzbd: 8082,
   seerr: 5055,
   bazarr: 6767,
+  suwayomi: 4567,
   pihole: 8081,
 } as const;
 
@@ -294,6 +296,39 @@ test.describe('UI screenshots', () => {
     await page.screenshot({ path: screenshotPath('bazarr'), fullPage: true });
   });
 
+  test('Kavita — login and screenshot library', async ({ page }) => {
+    const username = process.env.KAVITA_USERNAME;
+    const password = process.env.KAVITA_PASSWORD;
+    test.skip(!username || !password, 'KAVITA_USERNAME / KAVITA_PASSWORD not set');
+
+    await page.goto(url('kavita', '/login'));
+    await page.waitForLoadState('networkidle');
+
+    // Angular reactive form — formcontrolname is the stable hook
+    await page.fill('input[formcontrolname="username"], input[name="username"]', username!);
+    await page.fill('input[formcontrolname="password"], input[type="password"]', password!);
+    await page.click('button[type="submit"]');
+
+    // Kavita redirects to /home (or /library) once the JWT is stored
+    await page.waitForURL(/\/(home|library)/, { timeout: 15_000 });
+    await page.waitForLoadState('networkidle');
+
+    expect(page.url()).not.toContain('login');
+    await page.screenshot({ path: screenshotPath('kavita'), fullPage: true });
+  });
+
+  test('Suwayomi — screenshot library', async ({ page }) => {
+    // AUTH_MODE defaults to none, so there is no login step
+    await page.goto(url('suwayomi', '/'));
+    await page.waitForLoadState('domcontentloaded');
+
+    // React SPA — give it a moment to hydrate
+    await page.waitForTimeout(3_000);
+
+    await expect(page.locator('#root, #app, main').first()).toBeVisible({ timeout: 10_000 });
+    await page.screenshot({ path: screenshotPath('suwayomi'), fullPage: true });
+  });
+
   test('Pi-hole — login and screenshot admin', async ({ page }) => {
     const password = process.env.PIHOLE_PASSWORD;
     test.skip(!password, 'PIHOLE_PASSWORD not set');
@@ -411,5 +446,40 @@ test.describe('API assertions', () => {
     expect(res.ok()).toBeTruthy();
     const series = await res.json();
     expect(series.length).toBeGreaterThan(0);
+  });
+
+  test('Kavita — libraries live under /data/media', async ({ request }) => {
+    const username = process.env.KAVITA_USERNAME;
+    const password = process.env.KAVITA_PASSWORD;
+    test.skip(!username || !password, 'KAVITA_USERNAME / KAVITA_PASSWORD not set');
+
+    // Kavita issues a JWT rather than a static API key
+    const loginRes = await request.post(url('kavita', '/api/account/login'), {
+      data: { username, password },
+    });
+    expect(loginRes.ok()).toBeTruthy();
+    const { token } = await loginRes.json();
+
+    const res = await request.get(url('kavita', '/api/library/libraries'), {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.ok()).toBeTruthy();
+    const libraries: Array<{ folders: string[] }> = await res.json();
+    expect(libraries.length).toBeGreaterThan(0);
+    expect(libraries.flatMap((l) => l.folders)).toEqual(
+      expect.arrayContaining([expect.stringMatching(/^\/data\/media\//)]),
+    );
+  });
+
+  test('Suwayomi — GraphQL API responds through the VPN namespace', async ({ request }) => {
+    // No auth: AUTH_MODE defaults to none, and aboutServer is unauthenticated.
+    // Reaching it at all also proves Gluetun is publishing 4567.
+    const res = await request.post(url('suwayomi', '/api/graphql'), {
+      data: { query: '{ aboutServer { version github } }' },
+    });
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    expect(body.data.aboutServer.github).toBe('https://github.com/Suwayomi/Suwayomi-Server');
+    expect(body.data.aboutServer.version).toBeTruthy();
   });
 });

--- a/traefik/dynamic/local-services.yml
+++ b/traefik/dynamic/local-services.yml
@@ -22,6 +22,11 @@ http:
       entryPoints: [web]
       service: seerr-lan
 
+    kavita-lan:
+      rule: "Host(`kavita.lan`)"
+      entryPoints: [web]
+      service: kavita-lan
+
     # Legacy redirects (jellyseerr/jellyseer → seerr)
     jellyseerr-lan:
       rule: "Host(`jellyseerr.lan`)"
@@ -55,6 +60,11 @@ http:
       rule: "Host(`bazarr.lan`)"
       entryPoints: [web]
       service: bazarr-lan
+
+    suwayomi-lan:
+      rule: "Host(`suwayomi.lan`)"
+      entryPoints: [web]
+      service: suwayomi-lan
 
     # === Download Clients ===
     qbit-lan:
@@ -113,6 +123,11 @@ http:
         servers:
           - url: "http://172.20.0.8:5055"
 
+    kavita-lan:
+      loadBalancer:
+        servers:
+          - url: "http://172.20.0.17:5000"
+
     # === *arr Stack ===
     # Sonarr/Radarr now run on the arr-stack bridge with their own IPs
     # (no longer behind Gluetun). Prowlarr stays behind Gluetun (172.20.0.3).
@@ -135,6 +150,12 @@ http:
       loadBalancer:
         servers:
           - url: "http://172.20.0.9:6767"
+
+    # Suwayomi runs in Gluetun's namespace, so it answers on Gluetun's IP
+    suwayomi-lan:
+      loadBalancer:
+        servers:
+          - url: "http://172.20.0.3:4567"
 
     # === Download Clients (via Gluetun) ===
     qbit-lan:


### PR DESCRIPTION
Kavita on the arr-stack bridge (172.20.0.17:5000), Suwayomi behind Gluetun (port 4567 published on gluetun). The split follows the stack's existing rule: Suwayomi scrapes public scanlation sources — the same traffic class as Prowlarr's indexer scraping — so it gets the VPN; Kavita only serves files already on disk, like Jellyfin, so it doesn't.

The two hand off over the filesystem, not the network: Suwayomi writes .cbz chapters into MEDIA_ROOT/media/manga/mangas/<Source>/<Series>/ and Kavita mounts that tree read-only.

Three non-obvious config choices, all deliberate:
- DOWNLOAD_AS_CBZ=true — the default writes loose image folders, which Kavita does not recognise as series at all.
- KCEF_ENABLED=false — the bundled Chromium can't sandbox under this stack's no-new-privileges + cap_drop ALL, and a failed KCEF download is a known upstream startup hang. FlareSolverr on localhost:8191 covers the gap.
- Downloads are bind-mounted, not configured — upstream exposes no env var for the path, and the mount must precede the config volume or it is ignored.

Also swept: .lan routing (Traefik + dnsmasq + the pre-commit domain check), Uptime Kuma expected monitors, arr-backup volumes, SETUP.md media dirs, the REFERENCE/ARCHITECTURE tables, and four new E2E tests (14 -> 18).

NOT YET VERIFIED ON THE NAS — see CHANGELOG [Unreleased]. Per CLAUDE.md this must be deployed and confirmed working from this branch before it reaches main.