### PR TITLE
fix: give gluetun the two caps that cap_drop ALL takes away

### DIFF
--- a/docker-compose.arr-stack.yml
+++ b/docker-compose.arr-stack.yml
@@ -118,6 +118,26 @@ services:
         condition: service_healthy  # Wait for Pi-hole DNS before VPN connects
     cap_add:
       - NET_ADMIN
+      # gluetun runs as uid 0, but `cap_drop: ALL` above also takes away two
+      # caps the default Docker set would have handed it. It needs both back:
+      #
+      #   CHOWN        - gluetun chowns /etc/openvpn/target.ovpn. Only the
+      #                  OpenVPN path touches it, so VPN_TYPE=wireguard never
+      #                  notices, but VPN_TYPE=openvpn fails 100% of the time
+      #                  with "chown /etc/openvpn/target.ovpn: operation not
+      #                  permitted" and retries forever.
+      #   DAC_OVERRIDE - without it, root is subject to normal file permissions.
+      #                  OpenVPN then can't read back the file it just chowned
+      #                  away from itself ("--auth-user-pass fails with
+      #                  '/etc/openvpn/auth.conf': Permission denied"), and on
+      #                  EVERY VPN type gluetun can't write /tmp/gluetun/ip, so
+      #                  /v1/publicip/ip silently returns "" and the log fills
+      #                  with "clearing public IP data: permission denied".
+      #
+      # Adding NET_ADMIN alone looks right because every gluetun guide says
+      # that's all you need - true only because they don't drop the default caps.
+      - CHOWN
+      - DAC_OVERRIDE
     devices:
       - /dev/net/tun:/dev/net/tun
     volumes:

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -101,6 +101,25 @@
 
 > **Reaching VPN-side services from the bridge:** use the `gluetun` hostname (or `172.20.0.3`) — qBittorrent/SABnzbd/Prowlarr listen inside gluetun's namespace, so they have no Docker DNS name of their own. Gluetun's `FIREWALL_OUTBOUND_SUBNETS` includes `172.20.0.0/24`, so Prowlarr (in the VPN namespace) can reach Sonarr/Radarr on the bridge.
 
+> **Never point a container at a `.lan` name.** Those names all resolve to Traefik's
+> **macvlan** address (`192.168.1.11` in these docs). A macvlan interface is deliberately
+> unreachable from the container bridge on the same host, so *every* `.lan` URL fails from
+> inside a container — with IPv4 forced, and regardless of which `.lan` name it is. The
+> names are for browsers on your LAN, not for service-to-service configuration.
+>
+> This bites hardest in webhook and notification fields, where nothing validates the URL and
+> the only symptom is a health check going red days later:
+>
+> ```
+> # from inside Sonarr
+> curl http://homeassistant.lan:8123/api/webhook/...  → http=000   (Traefik's macvlan, and
+>                                                                   Traefik isn't on 8123)
+> curl http://192.168.1.20:8123/api/webhook/...       → http=200   (the device itself)
+> ```
+>
+> Address external devices by IP and their real port. Address other stack services by the
+> table above.
+
 ## Common Commands
 
 ```bash


### PR DESCRIPTION
`cap_drop: ALL` plus only `NET_ADMIN` also removes CHOWN and DAC_OVERRIDE, which gluetun quietly needs. Reported by a user deploying the stack on a UGREEN NAS, who worked around it with `privileged: true` — which "fixes" it only because it grants every capability, including the missing one.

**Two failures, one cause:**

- `VPN_TYPE=openvpn` never starts. gluetun chowns `/etc/openvpn/target.ovpn` and dies before dialling out, retrying on a 15s loop forever. `.env.example` documents `OPENVPN_USER`/`OPENVPN_PASSWORD`, so the stack advertises a path that cannot work.
- On **every** VPN type including the wireguard default, gluetun can't write `/tmp/gluetun/ip`. The running container had 347 permission-denied errors and `/v1/publicip/ip` had been returning `""` the whole time.

Reproduced all three cases against `qmcgaw/gluetun:v3.41` with throwaway containers and dummy credentials: NET_ADMIN alone gives the reported chown error, `+CHOWN` moves the failure to `auth.conf`, `+CHOWN +DAC_OVERRIDE` reaches the VPN handshake and fails only on AUTH_FAILED, as dummy credentials should.

**Verified on the NAS:**

```
docker exec gluetun sh -c 'echo test > /tmp/gluetun/probe'  → WRITE_OK
docker exec gluetun wget -qO- 127.0.0.1:8000/v1/publicip/ip → 143.244.42.75, Amsterdam
permission-denied errors in new log                         → 0
npm run test:e2e                                            → 37 passed, 1 skipped, 0 failed
```

**Also in this PR:** a docs note that a container must never be pointed at a `.lan` name — those resolve to Traefik's macvlan address, unreachable from the container bridge by design. Found because Sonarr's Home Assistant webhook was set to `homeassistant.lan:8123` and had been failing silently since at least 24 Aug; Radarr already had it right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)