### PR TITLE
fix: stop a Pi-hole wobble from tearing down the VPN

### DIFF
--- a/docker-compose.arr-stack.yml
+++ b/docker-compose.arr-stack.yml
@@ -151,6 +151,29 @@ services:
       - SERVER_COUNTRIES=${VPN_COUNTRIES}
       - TZ=${TZ}
       - DNS_ADDRESS=172.20.0.5
+      # Health check targets, deliberately IP:port and not hostnames.
+      #
+      # DNS_ADDRESS above disables gluetun's own resolver (it says so at every
+      # startup), making Pi-hole a hard dependency for all DNS. gluetun's
+      # default health targets are `github.com:443,cloudflare.com:443` — NAMES.
+      # So the check that decides whether the VPN is alive was being answered
+      # by Pi-hole, and a Pi-hole wobble was indistinguishable from a dead
+      # tunnel. gluetun's response is to rebuild the tunnel, which cannot fix
+      # DNS, so it loops — taking every VPN-side container's network with it on
+      # each pass, and never recovering on its own.
+      #
+      # On 2026-08-05 that produced 323 VPN rebuilds and 10 container restarts
+      # between 19:32 and 21:18. Pi-hole's own query log for the window shows
+      # it flapping rather than dead — multi-minute gaps, and 17 minutes at
+      # 2 queries/min against a 20–150/min baseline — and gluetun's restart
+      # clusters line up with the gaps. It stopped only when the container was
+      # restarted by hand.
+      #
+      # These addresses take DNS out of the decision entirely: the check now
+      # tests the tunnel and nothing else. DNS is still checked, but by
+      # scripts/check-vpn.sh, where failing means being told about it rather
+      # than having the VPN torn down in response.
+      - HEALTH_TARGET_ADDRESSES=1.1.1.1:443,8.8.8.8:443
       - FIREWALL_OUTBOUND_SUBNETS=${LAN_SUBNET},172.20.0.0/24,10.8.1.0/24
     ports:
       # Ports for services using network_mode: "service:gluetun"

--- a/docs/UTILITIES.md
+++ b/docs/UTILITIES.md
@@ -40,6 +40,53 @@ docker exec uptime-kuma sqlite3 /app/data/kuma.db "UPDATE monitor SET name='NewN
 docker restart uptime-kuma
 ```
 
+### The VPN check, and why it is a push monitor
+
+`scripts/check-vpn.sh` runs from cron every 5 minutes and pings a Kuma **push**
+monitor named `VPN Check` on success only. Kuma raises the alarm when the pings
+stop.
+
+That inversion is the point. An HTTP monitor asks "is the service answering?",
+which a leaking or unmeasurable VPN answers perfectly well. A push monitor asks
+"did the check run and pass?", so it also catches the case an HTTP monitor never
+can: the check itself not running. A dead cron and a healthy VPN look identical
+to everything else on this page.
+
+```bash
+# Create the push monitor (token is yours; generate a fresh 32-char one)
+TOKEN=$(head -c 24 /dev/urandom | md5sum | cut -c1-32)
+docker exec uptime-kuma sqlite3 /app/data/kuma.db \
+  "INSERT INTO monitor (name, active, type, interval, retry_interval, maxretries, \
+   push_token, user_id, upside_down, accepted_statuscodes_json, method) \
+   VALUES ('VPN Check', 1, 'push', 600, 60, 1, '$TOKEN', 1, 0, '[\"200-299\"]', 'GET');"
+
+# Attach your notification so it can actually reach you (id 1 = your default)
+MID=$(docker exec uptime-kuma sqlite3 /app/data/kuma.db "SELECT id FROM monitor WHERE name='VPN Check';")
+docker exec uptime-kuma sqlite3 /app/data/kuma.db \
+  "INSERT INTO monitor_notification (monitor_id, notification_id) VALUES ($MID, 1);"
+
+docker restart uptime-kuma
+echo "push URL: http://localhost:3001/api/push/$TOKEN"
+```
+
+The cron entry pushes only when the script exits 0, and logs the output when it
+does not:
+
+```cron
+*/5 * * * * /path/to/arr-stack/scripts/check-vpn.sh > /tmp/check-vpn.last 2>&1 && curl -fsS -m 10 "http://localhost:3001/api/push/YOUR_TOKEN?status=up&msg=OK" > /dev/null || { echo "--- $(date) ---"; cat /tmp/check-vpn.last; } >> /path/to/arr-stack/logs/check-vpn.log
+```
+
+The monitor interval is 600s against a 300s cron, so one slow or missed run does
+not page you; two consecutive failures do.
+
+> **Installing the crontab needs root on UGOS.** `crontab <file>` writes its temp
+> file into `/var/spool/cron/`, which the admin user cannot write, so it fails
+> with `mkstemp: Permission denied`. Writing
+> `/var/spool/cron/crontabs/<user>` directly *appears* to work — the file is
+> owned by the user — but cron never reloads it, and the entry silently never
+> runs. Verify with a `* * * * * date >> /tmp/canary.log` entry before trusting
+> it. Use `sudo crontab -u <user> <file>`.
+
 **Recommended monitors** (matching what the pre-commit check expects):
 
 | Monitor | Type | URL | Notes |

--- a/scripts/check-vpn.sh
+++ b/scripts/check-vpn.sh
@@ -84,6 +84,32 @@ fi
 echo "OK: Gluetun is tunneling"
 echo "  host egress: $HOST_IP"
 echo "  VPN egress:  $VPN_IP"
+# DNS is checked explicitly, and before egress, because gluetun's own health
+# check no longer looks at it. HEALTH_TARGET_ADDRESSES pins that check to bare
+# IPs on purpose (see docker-compose.arr-stack.yml): resolving names there made
+# a Pi-hole wobble indistinguishable from a dead tunnel, and gluetun answered by
+# rebuilding the tunnel in a loop that took every VPN-side container down with
+# it. Decoupling that is only safe if something else still watches DNS, and
+# this is that something.
+#
+# One probe covers all four services: they share gluetun's network namespace,
+# so they share its resolver. Checked ahead of egress because every egress
+# probe below resolves a hostname — with DNS down they all fail at once, and
+# without this the report would blame egress for a name-resolution fault.
+echo ""
+echo "Checking DNS inside the tunnel..."
+dns_server=$(docker exec gluetun sh -c "nslookup github.com 2>/dev/null | awk '/^Address:/{print \$2; exit}'" 2>/dev/null) || dns_server=""
+if docker exec gluetun sh -c 'nslookup github.com >/dev/null 2>&1' 2>/dev/null; then
+    echo "  OK:   names resolve inside gluetun's namespace (resolver ${dns_server:-unknown})"
+else
+    echo "  FAIL: DNS is not resolving inside gluetun's namespace."
+    echo "        Every tunneled service shares this resolver, so all of them are"
+    echo "        affected. DNS_ADDRESS points gluetun at Pi-hole (172.20.0.5) and"
+    echo "        disables its internal resolver, so start with Pi-hole:"
+    echo "        docker exec pihole dig @127.0.0.1 github.com +short"
+    exit 1
+fi
+
 echo ""
 echo "Checking tunneled services..."
 

--- a/scripts/check-vpn.sh
+++ b/scripts/check-vpn.sh
@@ -67,23 +67,6 @@ if [[ -z "$HOST_IP" ]]; then
     exit 1
 fi
 
-echo "Checking Gluetun's exit IP..."
-VPN_IP=$(egress_ip gluetun) || VPN_IP=""
-if [[ -z "$VPN_IP" ]]; then
-    echo "ERROR: Could not reach an IP-check service through Gluetun"
-    echo "       Gluetun may be down or the VPN disconnected"
-    exit 1
-fi
-
-if [[ "$VPN_IP" == "$HOST_IP" ]]; then
-    echo "LEAK DETECTED: Gluetun's egress ($VPN_IP) matches the host's ($HOST_IP)"
-    echo "               Gluetun is NOT routing through the VPN."
-    exit 1
-fi
-
-echo "OK: Gluetun is tunneling"
-echo "  host egress: $HOST_IP"
-echo "  VPN egress:  $VPN_IP"
 # DNS is checked explicitly, and before egress, because gluetun's own health
 # check no longer looks at it. HEALTH_TARGET_ADDRESSES pins that check to bare
 # IPs on purpose (see docker-compose.arr-stack.yml): resolving names there made
@@ -91,6 +74,13 @@ echo "  VPN egress:  $VPN_IP"
 # rebuilding the tunnel in a loop that took every VPN-side container down with
 # it. Decoupling that is only safe if something else still watches DNS, and
 # this is that something.
+#
+# It runs ahead of the Gluetun exit-IP check too, not just the per-service
+# ones. That check resolves ifconfig.me and exits the script on failure, so
+# with DNS down the whole run ended on "Gluetun may be down or the VPN
+# disconnected" — true only in the sense that nothing worked, and pointing
+# at the tunnel when the tunnel was fine. Found by staging the outage rather
+# than reasoning about it.
 #
 # One probe covers all four services: they share gluetun's network namespace,
 # so they share its resolver. Checked ahead of egress because every egress
@@ -110,6 +100,24 @@ else
     exit 1
 fi
 
+echo ""
+echo "Checking Gluetun's exit IP..."
+VPN_IP=$(egress_ip gluetun) || VPN_IP=""
+if [[ -z "$VPN_IP" ]]; then
+    echo "ERROR: Could not reach an IP-check service through Gluetun"
+    echo "       Gluetun may be down or the VPN disconnected"
+    exit 1
+fi
+
+if [[ "$VPN_IP" == "$HOST_IP" ]]; then
+    echo "LEAK DETECTED: Gluetun's egress ($VPN_IP) matches the host's ($HOST_IP)"
+    echo "               Gluetun is NOT routing through the VPN."
+    exit 1
+fi
+
+echo "OK: Gluetun is tunneling"
+echo "  host egress: $HOST_IP"
+echo "  VPN egress:  $VPN_IP"
 echo ""
 echo "Checking tunneled services..."
 

--- a/scripts/lib/check-uptime-monitors.sh
+++ b/scripts/lib/check-uptime-monitors.sh
@@ -20,6 +20,12 @@ check_uptime_monitors() {
         "Radarr"
         "Sonarr"
         "Traefik"
+        # Push monitor, not an HTTP one: scripts/check-vpn.sh pings it from cron
+        # every 5 minutes and Kuma alerts when the pings STOP. Listed here so
+        # that deleting it in the UI shows up as a warning — a monitor whose
+        # whole job is to notice silence fails silently when it is the thing
+        # that goes missing.
+        "VPN Check"
     )
 
     # Skip if NAS config not available


### PR DESCRIPTION
`DNS_ADDRESS=172.20.0.5` disables gluetun's internal resolver, and gluetun's health check resolved `github.com`/`cloudflare.com` **by name** — through Pi-hole. So a Pi-hole wobble was indistinguishable from a dead tunnel, and gluetun's response to a failed health check is to rebuild the tunnel: a remedy that cannot fix DNS, applied in a loop, taking every VPN-side container's network down on each pass. It never recovers on its own.

On 2026-08-05 that produced **323 VPN rebuilds and 10 container restarts** between 19:32 and 21:18, ending only when the container was restarted by hand.

Pi-hole was not down for that hour and three quarters. Its FTL query log — which survives container restarts, and was the only witness left — shows it *flapping*: multi-minute stretches of zero queries, and 17 minutes at 2 queries/min against a 20–150/min baseline. gluetun's restart clusters land inside those gaps.

`depends_on: pihole: condition: service_healthy` gives no protection: it orders startup, and Docker's restart policy doesn't re-evaluate it. Pi-hole's health check is a real `dig`, so it wasn't lying either.

## Staged the outage rather than reasoning about it

DNS to Pi-hole black-holed inside gluetun's namespace for 3m30s (iptables DROP, so no LAN impact), against a 1m healthcheck interval:

```
health:   healthy    (unchanged)
restarts: 0          (unchanged)
vpn-restart log lines: 0 (was 0)
DNS still dead? DEAD
```

Under the old config that window produced multiple `restarting VPN … lookup github.com … i/o timeout`.

## DNS is still watched — just not by something that reboots the tunnel

`check-vpn.sh` gains an explicit DNS probe. **This caught a real defect in my own change:** I first placed it *after* the Gluetun exit-IP check, which resolves `ifconfig.me` and exits early — so with DNS down the run ended on "Gluetun may be down or the VPN disconnected", pointing at the tunnel while the tunnel was fine. Reordered; now reports the actual cause.

## Cron + push monitor

The zombie guard already existed and worked — nothing ran it when it mattered. `check-vpn.sh` now runs every 5 min and pings a Kuma **push** monitor on success only, so Kuma alerts when the pings *stop* — which also catches the check not running at all.

| | result |
|---|---|
| pass | cron fired 18:05:07 and 18:10:04, both `msg=OK`, no failure log |
| fail | with DNS black-holed, heartbeat count unchanged at 3, diagnosis written to `logs/check-vpn.log` |

Bound to the existing default notification, and added to the pre-commit expected list.

**UGOS trap, documented:** `crontab <file>` can't write its temp file into `/var/spool/cron/` as the admin user. Writing `/var/spool/cron/crontabs/<user>` directly *looks* like it works — the file is user-owned, the write succeeds — but cron never reloads it and the entry silently never runs. A one-minute canary proved that; assuming otherwise would have left a monitoring setup that monitored nothing.

Verification: e2e green, 40/40 bats, shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)