### PR TITLE
chore: bump sabnzbd 5.1.1 -> 5.1.2

### DIFF
--- a/docker-compose.arr-stack.yml
+++ b/docker-compose.arr-stack.yml
@@ -240,7 +240,7 @@ services:
   # Access: sabnzbd.lan | sabnzbd.yourdomain.com | NAS_IP:8082
   # ═══════════════════════════════════════════════════════════════════════════
   sabnzbd:
-    image: lscr.io/linuxserver/sabnzbd:5.1.1
+    image: lscr.io/linuxserver/sabnzbd:5.1.2
     container_name: sabnzbd
     <<: *lsio-security
     network_mode: "service:gluetun"


### PR DESCRIPTION
Patch release, flagged by the pre-commit image-update check on every commit for the last several.

Config volume backed up first (`backups/sabnzbd-config-backup-20260827-181504.tgz`) per the CLAUDE.md rule on version bumps.

Verified on the NAS:

```
image=lscr.io/linuxserver/sabnzbd:5.1.2  health=healthy
API  {"version":"5.1.2"}
egress 143.244.42.75   (still via gluetun)
sonarr health=[]  radarr health=[]
```

e2e: 37 passed, 1 skipped, 0 failed.

Note on the first e2e attempt, which came back red across the whole VPN-security file: that was the NAS's SSH auto-disable timer firing mid-run, not this bump. Those tests use the SSH docker transport and are built to fail rather than skip when the NAS is unreachable — working as designed. Clean on re-run with SSH back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)