### PR TITLE
fix: gluetun also needs SETUID for the OpenVPN path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.10.1] - 2026-08-28
+
+1.10.0's OpenVPN fix was incomplete, and the way it was verified is why.
+
+### Fixed
+- **Gluetun also needs SETUID on the OpenVPN path.** Once the tunnel establishes, OpenVPN drops privileges and died on `setuid('nonrootuser') failed: Operation not permitted (errno=1)` — one step further than the chown error 1.10.0 fixed, and reported by the same person. gluetun writes `user nonrootuser` into `target.ovpn` unconditionally: its own settings summary prints "Run OpenVPN as: root" while writing that line, and `OPENVPN_PROCESS_USER=root` does not remove it either, so the setuid cannot be configured away. SETGID is deliberately not granted — there is no `group` directive and the tunnel completes without it.
+
+### Added
+- **`tests/openvpn-caps.bats` exercises the OpenVPN path against a real tunnel.** 1.10.0 was verified with dummy credentials, where OpenVPN exits at AUTH_FAILED — and setuid happens *after* authentication, so the check could not have observed the failure it claimed to rule out. Provider credentials were never the obstacle: a second container running OpenVPN in static-key mode is a real peer, with no PKI and no secrets in the repo. The test reads the capability list from `docker-compose.arr-stack.yml` rather than restating it, so it fails when that file changes, and it carries its own negative case — deleting the SETUID line fails it with the exact setuid error.
+
+
 ## [1.10.0] - 2026-08-27
 
 A reader's Gluetun wouldn't start on a UGREEN NAS. The capability that was missing turned out to break a second thing on every VPN type, and three more checks nearby turned out to be incapable of failing.

--- a/docker-compose.arr-stack.yml
+++ b/docker-compose.arr-stack.yml
@@ -118,8 +118,8 @@ services:
         condition: service_healthy  # Wait for Pi-hole DNS before VPN connects
     cap_add:
       - NET_ADMIN
-      # gluetun runs as uid 0, but `cap_drop: ALL` above also takes away two
-      # caps the default Docker set would have handed it. It needs both back:
+      # gluetun runs as uid 0, but `cap_drop: ALL` above also takes away caps
+      # the default Docker set would have handed it. It needs these back:
       #
       #   CHOWN        - gluetun chowns /etc/openvpn/target.ovpn. Only the
       #                  OpenVPN path touches it, so VPN_TYPE=wireguard never
@@ -138,6 +138,18 @@ services:
       # that's all you need - true only because they don't drop the default caps.
       - CHOWN
       - DAC_OVERRIDE
+      #   SETUID       - OpenVPN drops privileges to `nonrootuser` once the
+      #                  tunnel is up. gluetun writes `user nonrootuser` into
+      #                  target.ovpn unconditionally -- including when its own
+      #                  settings summary says "Run OpenVPN as: root", and even
+      #                  with OPENVPN_PROCESS_USER=root set -- so the setuid is
+      #                  not avoidable by configuration. Without this cap:
+      #                  "setuid('nonrootuser') failed: Operation not permitted
+      #                  (errno=1)" AFTER the tunnel establishes, so the peer
+      #                  connects and the link comes up before it dies.
+      #                  SETGID is deliberately NOT here: gluetun writes no
+      #                  `group` directive, and the tunnel completes without it.
+      - SETUID
     devices:
       - /dev/net/tun:/dev/net/tun
     volumes:

--- a/tests/openvpn-caps.bats
+++ b/tests/openvpn-caps.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# Does Gluetun's OpenVPN path actually work with the capabilities this repo
+# grants it?
+#
+# WHY THIS EXISTS
+#
+# `.env.example` documents OPENVPN_USER / OPENVPN_PASSWORD, so the stack
+# advertises an OpenVPN path — and until 1.10.1 that path had never been
+# exercised by anything. It was broken twice in a row, both times found by a
+# user rather than by us:
+#
+#   1.10.0  `cap_drop: ALL` removed CHOWN, so gluetun could not chown
+#           /etc/openvpn/target.ovpn and died before dialling out.
+#   1.10.1  it also removed SETUID, so OpenVPN died on
+#           `setuid('nonrootuser') failed` — but only AFTER the tunnel
+#           established, which is why fixing the first bug did not reveal
+#           the second.
+#
+# That second one matters for how this test is built. The 1.10.0 fix was
+# "verified" against dummy credentials, where OpenVPN exits at AUTH_FAILED —
+# and setuid happens after authentication, so the check could not have observed
+# the failure it claimed to rule out. A test that does not carry a tunnel all
+# the way up proves nothing about anything that happens after the handshake.
+#
+# Provider credentials were never the obstacle. A second container running
+# OpenVPN in static-key mode is a real peer: no PKI, no account, no secrets in
+# the repo. The client runs from the gluetun image itself, so the binary, libc
+# and capability behaviour are the ones that ship.
+#
+# The capability list is READ FROM docker-compose.arr-stack.yml rather than
+# written out here. A test carrying its own copy of the thing it validates
+# agrees with itself forever; this one fails when the compose file changes.
+
+setup() {
+    load helpers/setup
+
+    COMPOSE="$REPO_ROOT/docker-compose.arr-stack.yml"
+    NET="ovpn-caps-test-$$"
+    SERVER="ovpn-caps-server-$$"
+
+    command -v docker &>/dev/null || skip "docker is not available"
+    docker info &>/dev/null || skip "no running docker daemon"
+    # macOS has no /dev/net/tun on the host but its Linux VM does, so probe by
+    # running a container rather than testing the host path.
+    docker run --rm --device /dev/net/tun:/dev/net/tun alpine true &>/dev/null \
+        || skip "/dev/net/tun is not available to containers"
+
+    IMAGE="$(awk '/^  gluetun:/,/^    container_name:/' "$COMPOSE" \
+             | awk -F'image: *' '/image:/{print $2; exit}')"
+    [[ -n "$IMAGE" ]]
+
+    # Every bare `- CAPNAME` between cap_add: and devices: in the gluetun block.
+    # Comment lines are skipped by the pattern, which is why the heavily
+    # commented cap_add block in the compose file parses cleanly.
+    CAPS="$(awk '/^  gluetun:/,/^    devices:/' "$COMPOSE" \
+            | awk '/^    cap_add:/{f=1;next} /^    [a-z_]+:/{f=0} f && /^      - [A-Z_]+$/{print $2}')"
+    [[ -n "$CAPS" ]]
+
+    docker network create "$NET" &>/dev/null
+    docker run --rm -v "$BATS_TEST_TMPDIR:/out" --entrypoint /usr/sbin/openvpn2.6 \
+        "$IMAGE" --genkey secret /out/static.key &>/dev/null
+    [[ -s "$BATS_TEST_TMPDIR/static.key" ]]
+
+    docker run -d --name "$SERVER" --network "$NET" --cap-add NET_ADMIN \
+        --device /dev/net/tun:/dev/net/tun -v "$BATS_TEST_TMPDIR:/etc/ovpn:ro" \
+        --entrypoint /usr/sbin/openvpn2.6 "$IMAGE" \
+        --dev tun --proto udp --port 1194 --ifconfig 10.9.0.1 10.9.0.2 \
+        --secret /etc/ovpn/static.key --cipher AES-256-CBC &>/dev/null
+}
+
+teardown() {
+    [[ -n "${SERVER:-}" ]] && docker rm -f "$SERVER" &>/dev/null
+    [[ -n "${NET:-}" ]] && docker network rm "$NET" &>/dev/null
+    return 0
+}
+
+# Runs the OpenVPN client from the gluetun image with the given capabilities.
+# `--user nobody` stands in for gluetun's `nonrootuser`, which gluetun creates
+# at runtime from PUID/PGID and so does not exist when the entrypoint is
+# bypassed. The syscall and the capability required are identical; only the
+# target uid differs.
+run_client() {
+    local -a caps=()
+    local c
+    for c in "$@"; do caps+=(--cap-add "$c"); done
+
+    timeout 40 docker run --rm --network "$NET" --cap-drop ALL "${caps[@]}" \
+        --device /dev/net/tun:/dev/net/tun -v "$BATS_TEST_TMPDIR:/etc/ovpn:ro" \
+        --entrypoint /usr/sbin/openvpn2.6 "$IMAGE" \
+        --remote "$SERVER" 1194 --dev tun --proto udp \
+        --ifconfig 10.9.0.2 10.9.0.1 --secret /etc/ovpn/static.key \
+        --cipher AES-256-CBC --user nobody --verb 3 2>&1
+}
+
+@test "OpenVPN completes a tunnel with the capabilities the compose file grants" {
+    run run_client $CAPS
+    # Not merely "did not error". OpenVPN prints this only after it has brought
+    # the tunnel up AND dropped privileges — the two steps the last two bugs
+    # died between.
+    assert_output --partial "Initialization Sequence Completed"
+}
+
+@test "and fails without SETUID, so the check above can actually fail" {
+    # The negative case, in the suite rather than in a commit message. Without
+    # it the test above passes on any sufficiently permissive cap set and never
+    # tells anyone that the list it read had stopped mattering.
+    local without_setuid=()
+    local c
+    for c in $CAPS; do [[ "$c" == "SETUID" ]] || without_setuid+=("$c"); done
+
+    run run_client "${without_setuid[@]}"
+    assert_output --partial "setuid('nobody') failed: Operation not permitted"
+    refute_output --partial "Initialization Sequence Completed"
+}


### PR DESCRIPTION
1.10.0's OpenVPN fix was incomplete. Once the tunnel establishes, OpenVPN drops privileges and dies:

```
setuid('nonrootuser') failed: Operation not permitted (errno=1)
Exiting due to fatal error
```

Reported by the same person who found the original chown error, after pulling the fix and getting one step further.

**My verification for 1.10.0 could not have caught this.** I tested with dummy credentials and treated reaching AUTH_FAILED as proof the path was clear — but setuid happens *after* authentication, so everything past the handshake was untested and I reported it as verified. Same shape as the guards this repo keeps finding in itself: a check that ran, passed, and was structurally incapable of observing what it claimed to prove.

## Tested properly this time

Provider credentials were never the obstacle — a second container running OpenVPN in static-key mode is a real peer. No PKI, no account, no secrets. Client run from the gluetun image so the binary and libc are the ones that ship.

| caps | result |
|---|---|
| as in 1.10.0 | `setuid('nobody') failed: Operation not permitted` → fatal |
| + SETUID | `UID set to nobody` → **`Initialization Sequence Completed`** |

That second line is a tunnel that actually came up, which no amount of dummy-credential testing reaches.

SETGID is deliberately absent: gluetun writes `user nonrootuser` but no `group` directive, and the tunnel completes without it.

Not discoverable from config, so worth recording: gluetun writes that `user` line unconditionally. Its settings summary prints "Run OpenVPN as: root" while writing `user nonrootuser`, and `OPENVPN_PROCESS_USER=root` doesn't remove it either — both checked against v3.41.

## Now covered

`tests/openvpn-caps.bats` stands the server up and asserts the tunnel completes. It reads the capability list **from the compose file** rather than restating it — a test carrying its own copy of what it validates agrees with itself forever. Deleting the SETUID line fails it with the exact setuid error; verified by doing it. Carries its own negative case so the positive test can't quietly stop mattering.

Verification: 42/42 bats (up from 40), e2e 37 passed / 1 skipped / 0 failed, deployed and confirmed on the NAS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)