### PR TITLE
Harden against poisoned indexer results; make configure-apps dry-run truthful

### DIFF
--- a/scripts/configure-apps.sh
+++ b/scripts/configure-apps.sh
@@ -271,6 +271,17 @@ configure_qbittorrent() {
     local current_prefs
     current_prefs=$(curl -s -b "$QBIT_COOKIE" "${QBIT_URL}/api/v2/app/preferences" 2>/dev/null)
 
+    # Reject executables at the metadata stage, before any bytes transfer.
+    # Public torrent indexers serve droppers that impersonate real release groups:
+    # a ~1GB .exe padded to episode size, named e.g.
+    # "Reacher S04E08 1080p WEB H264-CAKES.exe". Sonarr does catch these on import
+    # ("Caution: Found executable file") but only AFTER the full download, and it
+    # cannot see one nested inside a folder until the release is already on disk.
+    # qBittorrent's exclusion list drops the matching files from the torrent
+    # up front, so a poisoned release arrives as a 0-byte no-op instead.
+    # See memory: indexer_poisoning_limetorrents (5 poisoned grabs, 2026-09-10).
+    local excluded_names='*.exe\n*.scr\n*.bat\n*.cmd\n*.com\n*.msi\n*.lnk\n*.vbs\n*.ps1\n*.jar'
+
     if json_extract "$current_prefs" "
 p = data
 if not p.get('auto_tmm_enabled', False): sys.exit(1)
@@ -285,6 +296,8 @@ if p.get('max_active_downloads', -1) != 5: sys.exit(1)
 if p.get('max_active_torrents', -1) != 10: sys.exit(1)
 if p.get('max_active_uploads', -1) != 5: sys.exit(1)
 if p.get('current_network_interface', '') != 'tun0': sys.exit(1)
+if not p.get('excluded_file_names_enabled', False): sys.exit(1)
+if p.get('excluded_file_names', '') != '${excluded_names}': sys.exit(1)
 "; then
         skip "qBittorrent: preferences"
     else
@@ -294,14 +307,14 @@ if p.get('current_network_interface', '') != 'tun0': sys.exit(1)
         # EPERM, so no announce escapes, no peers are found, and every torrent
         # stalls at metaDL while the WebUI and usenet both look healthy.
         # See docs/TROUBLESHOOTING.md -> "Torrents Stall Forever at 0% / metaDL".
-        local prefs='{"auto_tmm_enabled":true,"upnp":false,"limit_utp_rate":true,"limit_lan_peers":true,"encryption":1,"max_inactive_seeding_time_enabled":true,"max_inactive_seeding_time":30,"max_ratio_act":0,"max_active_downloads":5,"max_active_torrents":10,"max_active_uploads":5,"current_network_interface":"tun0","current_interface_address":""}'
+        local prefs='{"auto_tmm_enabled":true,"upnp":false,"limit_utp_rate":true,"limit_lan_peers":true,"encryption":1,"max_inactive_seeding_time_enabled":true,"max_inactive_seeding_time":30,"max_ratio_act":0,"max_active_downloads":5,"max_active_torrents":10,"max_active_uploads":5,"current_network_interface":"tun0","current_interface_address":"","excluded_file_names_enabled":true,"excluded_file_names":"'"${excluded_names}"'"}'
         http_code=$(curl -s -o /dev/null -w '%{http_code}' \
             -b "$QBIT_COOKIE" \
             --data-urlencode "json=${prefs}" \
             "${QBIT_URL}/api/v2/app/setPreferences")
 
         if [[ "$http_code" == "200" ]]; then
-            ok "qBittorrent: set preferences (auto TMM, UPnP off, encryption, stall timeout, concurrent limits, VPN interface binding)"
+            ok "qBittorrent: set preferences (auto TMM, UPnP off, encryption, stall timeout, concurrent limits, VPN interface binding, executable exclusions)"
         else
             fail "qBittorrent: set preferences (HTTP $http_code)"
         fi

--- a/scripts/configure-apps.sh
+++ b/scripts/configure-apps.sh
@@ -436,6 +436,7 @@ configure_bazarr() {
         dry "Enable subtitle sync (ffsubsync) with thresholds"
         dry "Enable Sub-Zero mods (remove tags, emoji, OCR fixes, common fixes, fix uppercase)"
         dry "Set default subtitle language to English"
+        dry "Enforce subtitle languages (en) in profiles and enabled list"
         return
     fi
 
@@ -637,6 +638,60 @@ print(' '.join(diff) if diff else 'MATCH')")
             needs_restart=true
         else
             fail "Bazarr: set default subtitle language"
+        fi
+    fi
+
+    # --- Subtitle language contents (English only) ---
+    #
+    # The step above only checks that profile 1 is the DEFAULT. It never looks
+    # at what profile 1 contains, so a stray language inside it reports as
+    # "already configured" forever. That is how Latvian ended up both in the
+    # profile and in the enabled-languages list, and Bazarr spent every nightly
+    # search hunting Latvian subtitles for the whole movie library (2026-09-10).
+    #
+    # Both key spaces must agree: the profile drives what gets searched; the
+    # enabled list is what the UI offers. POST semantics (Bazarr's
+    # api/system/settings.py): `languages-enabled` zeroes every language and
+    # then enables the listed ones, and `languages-profiles` is authoritative —
+    # any profileId missing from the payload is DELETED. So the full profile
+    # list is always read and sent back, with only the item filter applied.
+    local SUBTITLE_LANGUAGES="en"   # space-separated code2 list; edit to add languages
+    local lang_profiles enabled_langs lang_stray
+    lang_profiles=$(api_get "${BASE}/api/system/languages/profiles" "$AUTH") || true
+    enabled_langs=$(api_get "${BASE}/api/system/languages" "$AUTH") || true
+
+    lang_stray=$(python3 -c "
+import sys, json
+want = set(sys.argv[3].split())
+profiles = json.loads(sys.argv[1])
+enabled = {l['code2'] for l in json.loads(sys.argv[2]) if l.get('enabled')}
+stray = enabled - want
+for p in profiles:
+    stray |= {i['language'] for i in p['items']} - want
+print(' '.join(sorted(stray)) if stray else 'MATCH')
+" "$lang_profiles" "$enabled_langs" "$SUBTITLE_LANGUAGES" 2>/dev/null)
+
+    if [[ -z "$lang_stray" ]]; then
+        fail "Bazarr: could not read language profiles"
+    elif [[ "$lang_stray" == "MATCH" ]]; then
+        skip "Bazarr: subtitle languages (${SUBTITLE_LANGUAGES})"
+    else
+        local fixed_profiles
+        fixed_profiles=$(python3 -c "
+import sys, json
+want = set(sys.argv[2].split())
+profiles = json.loads(sys.argv[1])
+for p in profiles:
+    p['items'] = [i for i in p['items'] if i['language'] in want]
+print(json.dumps(profiles))
+" "$lang_profiles" "$SUBTITLE_LANGUAGES")
+        local enabled_args=()
+        for code in $SUBTITLE_LANGUAGES; do enabled_args+=("languages-enabled=${code}"); done
+        if bazarr_settings_post "$BASE" "$AUTH" "${enabled_args[@]}" "languages-profiles=${fixed_profiles}"; then
+            ok "Bazarr: removed stray subtitle language(s): ${lang_stray}"
+            needs_restart=true
+        else
+            fail "Bazarr: remove stray subtitle language(s): ${lang_stray}"
         fi
     fi
 

--- a/scripts/configure-apps.sh
+++ b/scripts/configure-apps.sh
@@ -48,6 +48,7 @@ QBIT_COOKIE="/tmp/qbit_configure_cookie.txt"
 CONFIGURED=0
 SKIPPED=0
 FAILED=0
+WOULD=0    # dry-run only: steps whose state check found them missing
 
 # API keys (discovered at runtime)
 SONARR_API_KEY=""
@@ -234,24 +235,30 @@ configure_qbittorrent() {
         return
     fi
 
-    if $DRY_RUN; then
-        dry "Authenticate to qBittorrent"
-        dry "Create category 'tv' → /data/torrents/tv"
-        dry "Create category 'movies' → /data/torrents/movies"
-        dry "Set preferences: auto TMM, disable UPnP, encryption, stall timeout, concurrent limits"
-        return
-    fi
-
-    # Authenticate using shared helper (see lib/configure-helpers.sh)
+    # Authenticate using shared helper (see lib/configure-helpers.sh).
+    # This runs in a dry run too: it is a session login, not a config write,
+    # and without it none of the state reads below are possible.
     local http_code
     if ! qbit_auth "$QBIT_URL" "$QBIT_USERNAME" "$QBIT_PASSWORD" "$QBIT_COOKIE"; then
         fail "qBittorrent: authentication failed (check QBIT_USERNAME/QBIT_PASSWORD)"
         return
     fi
 
-    # Create categories (409 = already exists, that's fine)
+    # Create categories. The list is read first so a dry run can tell "exists"
+    # from "would create" — inferring existence from a 409 on the write only
+    # works if the write is sent. 409 is still handled for the race case.
+    local existing_cats
+    existing_cats=$(curl -s -b "$QBIT_COOKIE" "${QBIT_URL}/api/v2/torrents/categories" 2>/dev/null)
     for cat_name in tv movies; do
         local save_path="/data/torrents/${cat_name}"
+        if json_extract "$existing_cats" "sys.exit(0 if '${cat_name}' in data else 1)"; then
+            skip "qBittorrent: category '${cat_name}'"
+            continue
+        fi
+        if $DRY_RUN; then
+            ok "qBittorrent: created category '${cat_name}' → ${save_path}"
+            continue
+        fi
         http_code=$(curl -s -o /dev/null -w '%{http_code}' \
             -b "$QBIT_COOKIE" \
             --data-urlencode "category=${cat_name}" \
@@ -308,10 +315,14 @@ if p.get('excluded_file_names', '') != '${excluded_names}': sys.exit(1)
         # stalls at metaDL while the WebUI and usenet both look healthy.
         # See docs/TROUBLESHOOTING.md -> "Torrents Stall Forever at 0% / metaDL".
         local prefs='{"auto_tmm_enabled":true,"upnp":false,"limit_utp_rate":true,"limit_lan_peers":true,"encryption":1,"max_inactive_seeding_time_enabled":true,"max_inactive_seeding_time":30,"max_ratio_act":0,"max_active_downloads":5,"max_active_torrents":10,"max_active_uploads":5,"current_network_interface":"tun0","current_interface_address":"","excluded_file_names_enabled":true,"excluded_file_names":"'"${excluded_names}"'"}'
-        http_code=$(curl -s -o /dev/null -w '%{http_code}' \
-            -b "$QBIT_COOKIE" \
-            --data-urlencode "json=${prefs}" \
-            "${QBIT_URL}/api/v2/app/setPreferences")
+        if $DRY_RUN; then
+            http_code=200
+        else
+            http_code=$(curl -s -o /dev/null -w '%{http_code}' \
+                -b "$QBIT_COOKIE" \
+                --data-urlencode "json=${prefs}" \
+                "${QBIT_URL}/api/v2/app/setPreferences")
+        fi
 
         if [[ "$http_code" == "200" ]]; then
             ok "qBittorrent: set preferences (auto TMM, UPnP off, encryption, stall timeout, concurrent limits, VPN interface binding, executable exclusions)"
@@ -361,13 +372,6 @@ configure_prowlarr() {
     local AUTH="X-Api-Key: ${PROWLARR_API_KEY}"
 
     if ! wait_for_service "Prowlarr" "${BASE}/api/v1/health"; then return; fi
-
-    if $DRY_RUN; then
-        dry "Add FlareSolverr indexer proxy"
-        dry "Add Sonarr application sync"
-        dry "Add Radarr application sync"
-        return
-    fi
 
     # FlareSolverr proxy
     local proxies
@@ -429,16 +433,6 @@ configure_bazarr() {
     local AUTH="X-API-KEY: ${BAZARR_API_KEY}"
 
     if ! wait_for_service "Bazarr" "${BASE}/api/system/status"; then return; fi
-
-    if $DRY_RUN; then
-        dry "Connect Bazarr to Sonarr (sonarr:8989)"
-        dry "Connect Bazarr to Radarr (radarr:7878)"
-        dry "Enable subtitle sync (ffsubsync) with thresholds"
-        dry "Enable Sub-Zero mods (remove tags, emoji, OCR fixes, common fixes, fix uppercase)"
-        dry "Set default subtitle language to English"
-        dry "Enforce subtitle languages (en) in profiles and enabled list"
-        return
-    fi
 
     # Get current settings
     local settings
@@ -695,8 +689,8 @@ print(json.dumps(profiles))
         fi
     fi
 
-    # Restart if any changes were made
-    if $needs_restart; then
+    # Restart if any changes were made (never in a dry run — nothing was written)
+    if $needs_restart && ! $DRY_RUN; then
         info "Restarting Bazarr to apply changes..."
         docker restart bazarr >/dev/null 2>&1
     fi
@@ -709,11 +703,6 @@ print(json.dumps(profiles))
 configure_pihole() {
     log "Configuring Pi-hole..."
 
-    if $DRY_RUN; then
-        dry "Set Pi-hole upstream DNS to dnscrypt-proxy (172.20.0.6#5053)"
-        return
-    fi
-
     # Check current upstream DNS configuration
     local current_dns
     current_dns=$(docker exec pihole pihole-FTL --config dns.upstreams 2>/dev/null || true)
@@ -722,7 +711,9 @@ configure_pihole() {
         skip "Pi-hole: upstream DNS (already using dnscrypt-proxy)"
     else
         # Set dnscrypt-proxy as upstream DNS using FTL config
-        if docker exec pihole pihole-FTL --config dns.upstreams '["172.20.0.6#5053"]' >/dev/null 2>&1; then
+        if $DRY_RUN; then
+            ok "Pi-hole: set upstream DNS to dnscrypt-proxy (172.20.0.6#5053)"
+        elif docker exec pihole pihole-FTL --config dns.upstreams '["172.20.0.6#5053"]' >/dev/null 2>&1; then
             ok "Pi-hole: set upstream DNS to dnscrypt-proxy (172.20.0.6#5053)"
             # Restart container to apply — pihole restartdns fails with cap_drop: ALL
             docker restart pihole >/dev/null 2>&1
@@ -756,7 +747,11 @@ configure_pihole
 
 echo ""
 echo "=========================================="
-echo "Summary: ${CONFIGURED} configured, ${SKIPPED} skipped, ${FAILED} failed"
+if $DRY_RUN; then
+    echo "Summary (dry-run): ${WOULD} would change, ${SKIPPED} already configured, ${FAILED} could not be checked"
+else
+    echo "Summary: ${CONFIGURED} configured, ${SKIPPED} skipped, ${FAILED} failed"
+fi
 echo "=========================================="
 
 if [[ $FAILED -gt 0 ]]; then

--- a/scripts/lib/configure-helpers.sh
+++ b/scripts/lib/configure-helpers.sh
@@ -29,11 +29,21 @@ $expr
 # ============================================
 
 log()   { echo "[configure] $1"; }
-ok()    { echo "  ✓ $1"; CONFIGURED=$((CONFIGURED + 1)); }
+# In a dry run, ok() is reached only after the same state check a real run
+# performs, and the write it would have followed was suppressed at the choke
+# points (_api_request, bazarr_settings_post, and the few raw curl/docker
+# sites in configure-apps.sh). So "Would:" here means "checked, and missing" —
+# not "listed unconditionally", which is what the old early-return blocks did.
+ok() {
+    if [[ "${DRY_RUN:-false}" == "true" ]]; then
+        echo "  [dry-run] Would: $1"; WOULD=$((WOULD + 1))
+    else
+        echo "  ✓ $1"; CONFIGURED=$((CONFIGURED + 1))
+    fi
+}
 skip()  { echo "  - $1 (already configured)"; SKIPPED=$((SKIPPED + 1)); }
 fail()  { echo "  ✗ $1"; FAILED=$((FAILED + 1)); }
 info()  { echo "  $1"; }
-dry()   { echo "  [dry-run] Would: $1"; }
 
 # ============================================
 # HTTP helpers
@@ -50,6 +60,9 @@ _api_request() {
         if [[ -n "$data" ]]; then args+=(--data "$data"); fi
     fi
     for h in "$@"; do args+=(-H "$h"); done
+    # Dry run: reads go through so state checks are real; writes are reported
+    # as done without being sent.
+    if [[ "${DRY_RUN:-false}" == "true" && "$method" != "GET" ]]; then return 0; fi
     local response
     response=$(curl "${args[@]}" "$url")
     local code
@@ -176,6 +189,10 @@ bazarr_settings_post() {
     local kv
     for kv in "$@"; do args+=(--data-urlencode "$kv"); done
 
+    # Dry run: never sent. Bazarr restarts itself on every accepted settings
+    # POST, so a dry run that leaked one would also bounce the container.
+    if [[ "${DRY_RUN:-false}" == "true" ]]; then return 0; fi
+
     local response code body
     response=$(curl "${args[@]}" "${BASE}/api/system/settings")
     code=$(echo "$response" | tail -1)
@@ -218,8 +235,15 @@ print(ids[0] if ids else '')")
     else
         local cf_payload cf_result
         cf_payload="{\"name\":\"${cf_name}\",\"includeCustomFormatWhenRenaming\":false,\"specifications\":${cf_specs}}"
-        cf_result=$(api_post "${BASE}/api/v3/customformat" "application/json" "$cf_payload" "$AUTH") || true
-        cf_id=$(json_extract "$cf_result" "print(data.get('id', ''))")
+        if [[ "${DRY_RUN:-false}" == "true" ]]; then
+            # No id comes back from a write that was never sent. -1 matches no
+            # profile's formatItems, so the loop below reports every profile as
+            # needing the score — which is exactly what a real run would do.
+            cf_id=-1
+        else
+            cf_result=$(api_post "${BASE}/api/v3/customformat" "application/json" "$cf_payload" "$AUTH") || true
+            cf_id=$(json_extract "$cf_result" "print(data.get('id', ''))")
+        fi
         if [[ -n "$cf_id" ]]; then
             ok "${name}: added ${cf_name} custom format"
         else
@@ -307,22 +331,6 @@ configure_arr_service() {
         cat_field="movieCategory"
         priority_recent="recentMoviePriority"
         priority_older="olderMoviePriority"
-    fi
-
-    if $DRY_RUN; then
-        dry "Add root folder ${root_path}"
-        dry "Add qBittorrent download client (category: ${category})"
-        if $SABNZBD_RUNNING; then dry "Add SABnzbd download client (category: ${category})"; fi
-        dry "Enable NFO metadata (Kodi/Emby)"
-        dry "Set TRaSH naming scheme"
-        dry "Add Reject ISO custom format"
-        dry "Score Reject ISO at -10000 in quality profiles"
-        dry "Add DV (Profile 5) custom format"
-        dry "Score DV (Profile 5) at -1000 in quality profiles"
-        dry "Add DV HDR10 (Profile 8.1) custom format"
-        dry "Score DV HDR10 (Profile 8.1) at 500 in quality profiles"
-        if $SABNZBD_RUNNING; then dry "Add delay profile (Usenet 0, Torrent 30)"; fi
-        return
     fi
 
     # --- Root folder ---

--- a/scripts/scan-executables.sh
+++ b/scripts/scan-executables.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+set -euo pipefail
+#
+# Report executable files sitting in the media and download trees.
+#
+# ⚠️  This script was generated with LLM assistance and human-reviewed.
+#     Read and understand it before running. Do not execute scripts you
+#     don't understand on your system. It only inspects and reports —
+#     it changes nothing.
+#
+# THE FAILURE IT LOOKS FOR
+#
+# Public torrent indexers have no upload vetting, and the standard abuse of that
+# is a dropper wearing a release's name: a ~1GB Windows executable padded to
+# episode size, called something like
+# "Reacher S04E08 1080p WEB H264-CAKES.exe", uploaded under a real release
+# group's tag so it ranks against every new-episode search.
+#
+# Two layers already stand against this and neither is sufficient alone:
+#
+#   1. qBittorrent's exclusion list (configure-apps.sh, `excluded_file_names`)
+#      drops the matching files before any bytes transfer. It only protects
+#      torrents added AFTER it was set, and only on this client — anything
+#      already on disk, hand-added, or arriving via usenet bypasses it.
+#
+#   2. Sonarr/Radarr refuse to import a release containing an executable
+#      ("Caution: Found executable file"). That check fires only at import,
+#      i.e. after the full download has landed, and a refused import leaves
+#      the payload sitting in the download directory indefinitely.
+#
+# So the steady state this catches is: a dropper that was downloaded, correctly
+# refused by the *arr, and then simply left on disk — inert on the NAS, which is
+# Linux, but one SMB browse away from a Windows machine where it is not inert.
+#
+# On 2026-09-10 that was three files totalling ~2.9GB, found only because
+# someone happened to look.
+#
+# Patterns are kept in step with the qBittorrent exclusion list set by
+# scripts/configure-apps.sh. Changing one without the other leaves a gap.
+#
+# Usage:
+#   ./scripts/scan-executables.sh            # scan, report, exit non-zero on findings
+#   ./scripts/scan-executables.sh --quiet    # print only findings (for cron)
+#
+# Exit codes:
+#   0 = no executables found
+#   1 = at least one found, or the scan could not be completed
+#
+# Reasonable to run on a timer:
+#   0 4 * * 0 /path/to/arr-stack/scripts/scan-executables.sh --quiet || notify "executable in media tree"
+
+QUIET=false
+[[ "${1:-}" == "--quiet" ]] && QUIET=true
+
+# Extensions must mirror `excluded_names` in scripts/configure-apps.sh.
+PATTERNS=(exe scr bat cmd com msi lnk vbs ps1 jar)
+
+log() { $QUIET || echo "$@"; }
+
+# Scan from inside a container rather than against a host path: the /data mount
+# is the same tree for every service, so this works regardless of where the
+# volume actually lives on the host. Sonarr is on the bridge and does not depend
+# on the VPN being up, which makes it the most reliable entry point.
+CONTAINER=""
+for c in sonarr radarr qbittorrent; do
+    if docker inspect -f '{{.State.Running}}' "$c" 2>/dev/null | grep -q true; then
+        CONTAINER="$c"
+        break
+    fi
+done
+
+if [[ -z "$CONTAINER" ]]; then
+    echo "ERROR: no running container with /data mounted (tried sonarr, radarr, qbittorrent)." >&2
+    echo "       Cannot scan. This is a failure, not a clean result." >&2
+    exit 1
+fi
+
+log "Scanning /data via $CONTAINER for: ${PATTERNS[*]}"
+
+# Build a single find expression: -iname '*.exe' -o -iname '*.scr' -o ...
+find_args=()
+for i in "${!PATTERNS[@]}"; do
+    [[ $i -gt 0 ]] && find_args+=(-o)
+    find_args+=(-iname "*.${PATTERNS[$i]}")
+done
+
+# find exits non-zero on unreadable subdirectories, which must not be mistaken
+# for "found nothing" — capture status separately from output.
+set +e
+hits=$(docker exec "$CONTAINER" find /data \( "${find_args[@]}" \) -type f -printf '%s\t%p\n' 2>/dev/null)
+find_status=$?
+set -e
+
+if [[ $find_status -ne 0 && -z "$hits" ]]; then
+    echo "ERROR: find failed inside $CONTAINER (exit $find_status). Scan result is unknown." >&2
+    exit 1
+fi
+
+if [[ -z "$hits" ]]; then
+    log "Clean: no executables under /data."
+    exit 0
+fi
+
+count=$(echo "$hits" | wc -l | tr -d ' ')
+echo "FOUND $count executable file(s) under /data:" >&2
+echo "$hits" | awk -F'\t' '{ printf "  %6.1f MB  %s\n", $1/1048576, $2 }' >&2
+echo >&2
+echo "These should not be here. Verify each, then delete it and blocklist the" >&2
+echo "release in Sonarr/Radarr so the same grab is not repeated." >&2
+exit 1

--- a/tests/e2e/media-hygiene.spec.ts
+++ b/tests/e2e/media-hygiene.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { requireStackReachable, dockerExec } from './helpers';
+
+// Added 2026-09-10, after LimeTorrents served five poisoned results in one day:
+// three ~1GB Windows executables impersonating real release groups, plus two
+// season packs mislabeled S06 that actually contained S05.
+//
+// Sonarr refused every one of them ("Caution: Found executable file"), so
+// nothing reached the library — but a refused import leaves the payload in the
+// download directory, where it sat unnoticed until someone happened to look.
+// Inert on the NAS, which is Linux. Not inert one SMB browse away.
+//
+// This asserts the steady state rather than the defense: no executables under
+// /data, whatever combination of qBittorrent exclusions, *arr import checks and
+// manual cleanup got us there.
+
+// Extensions mirror `excluded_names` in scripts/configure-apps.sh and PATTERNS
+// in scripts/scan-executables.sh. All three must be changed together.
+const EXECUTABLE_EXTENSIONS = ['exe', 'scr', 'bat', 'cmd', 'com', 'msi', 'lnk', 'vbs', 'ps1', 'jar'];
+
+test.describe('Media hygiene', () => {
+  test('no executable files anywhere under /data', () => {
+    requireStackReachable(test.skip);
+
+    const findExpr = EXECUTABLE_EXTENSIONS.flatMap((ext, i) =>
+      i === 0 ? ['-iname', `*.${ext}`] : ['-o', '-iname', `*.${ext}`],
+    );
+
+    // Scanned from inside Sonarr: it sees the same /data mount as every other
+    // service and sits on the bridge, so this does not depend on the VPN.
+    const output = dockerExec(
+      'sonarr',
+      ['find', '/data', '(', ...findExpr, ')', '-type', 'f'],
+      30_000,
+    ).trim();
+
+    const hits = output ? output.split('\n').filter(Boolean) : [];
+
+    // Name the files in the failure. "Expected 0, got 3" would send you hunting
+    // for something this test already knows the path of.
+    expect(hits, `Executable file(s) found under /data:\n${hits.join('\n')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

On 2026-09-10 LimeTorrents served five poisoned results against routine new-episode searches: three ~1 GB Windows executables impersonating real release groups, and two "S06" season packs that actually contained S05. Sonarr refused all of them on import, so nothing reached the library — but ~2.9 GB of malware sat in `/data/torrents/tv` unnoticed, and nothing would ever have looked.

## What

- **qBittorrent rejects executables at the metadata stage** (`excluded_file_names`, via `configure-apps.sh`) — a poisoned release now arrives as a no-op instead of a full download followed by a refused import.
- **`scripts/scan-executables.sh`** reports anything already on disk; **`tests/e2e/media-hygiene.spec.ts`** asserts the steady state. Both proven to fail on a planted decoy.
- **Bazarr now enforces which subtitle languages it searches** — the old step only checked profile 1 was the *default*, never its contents, which is how Latvian sat in it while reporting "already configured".
- **`--dry-run` reports real deltas.** It used to print "Would:" for all 29 settings unconditionally and end `0 configured, 0 skipped`. Writes are now suppressed at the choke points and state reads run in both modes. Proven with a canary: a missing category is reported and not created.

Live changes made alongside (not in this diff): LimeTorrents, TPB and YTS disabled in Prowlarr; EZTV/showRSS at priority 50, NZBgeek at 10.

## Verified on the NAS

- `configure-apps.sh`: `1 configured, 29 skipped` → re-run `0 configured, 30 skipped`
- `--dry-run`: `0 would change, 30 already configured`, container start-times unchanged
- Canary dry-run: `1 would change`, category not created
- `npm run test:e2e`: 38 passed, 1 skipped (killswitch, expected)
- `tests/run-tests.sh`: 42/42, shellcheck included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
