### PR TITLE
Bump five routine images (cloudflared, docker-cli, beszel, beszel-agent, sabnzbd)

### DIFF
--- a/docker-compose.arr-stack.yml
+++ b/docker-compose.arr-stack.yml
@@ -252,7 +252,7 @@ services:
   # Access: sabnzbd.lan | sabnzbd.yourdomain.com | NAS_IP:8082
   # ═══════════════════════════════════════════════════════════════════════════
   sabnzbd:
-    image: lscr.io/linuxserver/sabnzbd:5.1.2
+    image: lscr.io/linuxserver/sabnzbd:5.1.3
     container_name: sabnzbd
     <<: *lsio-security
     network_mode: "service:gluetun"

--- a/docker-compose.cloudflared.yml
+++ b/docker-compose.cloudflared.yml
@@ -19,7 +19,7 @@ name: cloudflared
 
 services:
   cloudflared:
-    image: cloudflare/cloudflared:2026.8.2
+    image: cloudflare/cloudflared:2026.9.0
     container_name: cloudflared
     security_opt:
       - no-new-privileges:true

--- a/docker-compose.utilities.yml
+++ b/docker-compose.utilities.yml
@@ -98,7 +98,7 @@ services:
   # See TROUBLESHOOTING.md "After a Gluetun RECREATE".
   # ═══════════════════════════════════════════════════════════════════════════
   gluetun-recover:
-    image: docker:29.7-cli
+    image: docker:29.8-cli
     container_name: gluetun-recover
     <<: *default-security
     volumes:
@@ -221,7 +221,7 @@ services:
   # Access: beszel.lan | NAS_IP:8090 (LAN-only, use WireGuard for remote)
   # ═══════════════════════════════════════════════════════════════════════════
   beszel:
-    image: henrygd/beszel:0.18
+    image: henrygd/beszel:0.19
     container_name: beszel
     <<: *default-security
     cap_add:
@@ -248,7 +248,7 @@ services:
       start_period: 30s
 
   beszel-agent:
-    image: henrygd/beszel-agent:0.18
+    image: henrygd/beszel-agent:0.19
     container_name: beszel-agent
     <<: *default-security
     restart: always


### PR DESCRIPTION
Five routine image bumps flagged by the pre-commit check on 2026-09-10. Jellyfin 10.11 → 12.0 is deliberately excluded — major version with a DB migration, own branch, config backup first.

| Service | From | To |
|---|---|---|
| cloudflared | 2026.8.2 | 2026.9.0 |
| docker cli (gluetun-recover) | 29.7 | 29.8 |
| beszel / beszel-agent | 0.18 | 0.19 |
| sabnzbd | 5.1.2 | 5.1.3 |

## Verified on the NAS

- beszel-data and sabnzbd-config volumes backed up to the USB backup dir first
- Compose `--dry-run` per defining file before each recreate: only the intended containers listed; gluetun untouched by the SABnzbd recreate (still up 7 days after)
- All five healthy; versions confirmed from inside the containers / APIs (`cloudflared version 2026.9.0`, `Docker version 29.8.0`, SABnzbd `{"version":"5.1.3"}`, Beszel UI 200)
- cloudflared tunnel re-registered (2 QUIC connections, lhr)
- `detect-vpn-zombies.sh`: SABnzbd inside Gluetun's current namespace
- `npm run test:e2e`: 38 passed, 1 skipped (killswitch, expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
