### PR TITLE
Bump Jellyfin 10.11 → 12.0; document the two upgrade traps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+A public indexer served malware for a day, the stack's defences held, and the tool meant to preview changes turned out to be incapable of previewing anything.
+
+### Added
+- **qBittorrent rejects executables at the metadata stage** (`excluded_file_names`, set by `configure-apps.sh`). On 2026-09-10 LimeTorrents served five poisoned results against routine new-episode searches: three ~1 GB Windows executables named after real release groups (CAKES, ETHEL), and two "S06" season packs that actually contained S05. Sonarr refused every one on import ("Caution: Found executable file"), so nothing reached the library — but the refusal happens *after* the full download, and ~2.9 GB of malware then sat in `/data/torrents/tv` where nothing would ever have looked. Now a poisoned release arrives as a no-op.
+- **`scripts/scan-executables.sh`** reports executables already on disk, on demand or from cron; **`tests/e2e/media-hygiene.spec.ts`** asserts the steady state. Both were proven to fail on a planted decoy before being trusted.
+- **Bazarr enforces which subtitle languages it searches for.** The existing step only checked that profile 1 was the *default*, never what it contained, which is how Latvian sat inside it while reporting "already configured" — and Bazarr spent every nightly search hunting Latvian subtitles for the whole movie library. The POST semantics were read from Bazarr's own `api/system/settings.py`: `languages-profiles` is authoritative and deletes any profile you leave out, so the full list is always read and sent back.
+
+### Fixed
+- **`configure-apps.sh --dry-run` reports real deltas.** Every section opened with an early-return block that printed "Would:" for all 29 settings unconditionally and ended `0 configured, 0 skipped` — it could not distinguish already-set from missing, which is the one thing a dry run exists to do. State reads now run in both modes and only the writes are suppressed, at the choke points every write already passes through. Proven with a canary: a missing category is reported as `Would:` and not created.
+
+### Changed
+- **Image bumps** — `cloudflared` 2026.8.2 → 2026.9.0, `docker` cli 29.7 → 29.8 (gluetun-recover), `beszel` and `beszel-agent` 0.18 → 0.19, `sabnzbd` 5.1.2 → 5.1.3, `jellyfin` 10.11 → 12.0 (major; config volume backed up first, all 34 migrations verified in the logs, `Startup complete` in 3m41s). Two traps found on the way, both in `docs/UPGRADING.md`: 12.0 rejects the `<EncoderPreset xsi:nil="true" />` that 10.11 writes and silently resets hardware transcoding to defaults — acceleration `none`, tonemapping off — while playback carries on in software; and its healthcheck reports healthy about ten seconds in, while the migration is still running.
+- **Live Prowlarr changes, not in this repo:** LimeTorrents, The Pirate Bay and YTS disabled; EZTV and showRSS dropped to priority 50 with NZBgeek at 10. Every indexer had been sitting at the default 25, so usenet held no ranking advantage. The delay profile (usenet 0 min / torrent 30 min) was already correct and is not the control here — it sequences protocols, it does not vet content.
+
+
 ## [1.10.1] - 2026-08-28
 
 1.10.0's OpenVPN fix was incomplete, and the way it was verified is why.

--- a/docker-compose.arr-stack.yml
+++ b/docker-compose.arr-stack.yml
@@ -385,7 +385,7 @@ services:
   # Access: jellyfin.lan | jellyfin.yourdomain.com | NAS_IP:8096
   # ═══════════════════════════════════════════════════════════════════════════
   jellyfin:
-    image: jellyfin/jellyfin:10.11
+    image: jellyfin/jellyfin:12.0
     container_name: jellyfin
     <<: *default-security
     cap_add:

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -40,6 +40,28 @@ docker compose -f docker-compose.arr-stack.yml up -d  # Restarts containers with
 
 When upgrading across versions, check below for any action required.
 
+### Jellyfin 10.11 → 12.0 (image bump)
+
+12.0 rewrites the database on first start and a backup is the only way back. Direct upgrade from 10.11.x is supported. Two things the release notes don't say, both hit on this stack on 2026-09-10:
+
+**1. Hardware transcoding settings are silently reset** if `encoding.xml` contains `<EncoderPreset xsi:nil="true" />` — which is what 10.11 writes when the preset was never touched. 12.0's parser rejects the empty value, logs a single `[ERR] Error loading configuration file: /config/config/encoding.xml`, and rewrites the file with defaults: acceleration `none`, VPP tonemapping off, HEVC encoding off, and hevc/vp9/vp8/mpeg2 dropped from hardware decoding. Playback keeps working — in software — so nothing alerts you. With Jellyfin stopped, fix the preset before pulling the new image:
+
+```bash
+docker stop jellyfin
+docker run --rm -v arr-stack_jellyfin-config:/src alpine \
+  sed -i 's|<EncoderPreset xsi:nil="true" />|<EncoderPreset>auto</EncoderPreset>|' /src/config/encoding.xml
+```
+
+If you have already upgraded, compare `/config/config/encoding.xml` against your backup's copy and put the values back (or re-enter them in Dashboard → Playback → Transcoding). Look for that `[ERR]` line in the first-boot log either way.
+
+**2. The healthcheck goes green before the migration finishes.** `/health` answered 200 about ten seconds in; `Startup complete` arrived 3m41s later. `docker ps` reporting healthy is not the signal — wait for:
+
+```bash
+docker logs jellyfin 2>&1 | grep "Startup complete"
+```
+
+Seerr logs a `503` if its library sync lands in that window; it recovers on the next run. For scale: backing up a 4 GB config volume with `tar` from a throwaway container took about 13 minutes on the NAS.
+
 ### v1.7.9 → v1.7.10
 
 Docs-only fix. No migration needed — just `git pull`.


### PR DESCRIPTION
## Jellyfin 10.11.11 → 12.0.0

Major version with a first-boot database rewrite (no rollback except restore). Pre-flight before flipping it: no third-party server plugins installed; jellyfin-kodi 2.1.0 on the Fire TV Cube does not use the removed `/emby/` prefix (its two matches are a path-cleanup migration); Android TV client 0.19.10.

## What happened on the NAS

- jellyfin-config volume (4 GB) backed up to the USB backup dir first; archive verified to contain every `.db` the live volume has.
- Compose `--dry-run` listed only `jellyfin`. Recreated. 34 migrations applied, `Startup complete 0:03:41`.
- **Trap 1 — hardware transcoding silently reset.** 12.0 rejected the `<EncoderPreset xsi:nil="true" />` that 10.11 writes, logged one `[ERR]`, and rewrote `encoding.xml` with defaults (acceleration `none`, VPP tonemapping off, HEVC encoding off, hevc/vp9/vp8/mpeg2 dropped from hw decoding). Caught by diffing against the backup. Restored with Jellyfin stopped; second boot loaded it cleanly (`Startup complete` 4.8 s, zero config-load errors, values intact after start).
- **Trap 2 — healthcheck green mid-migration.** `/health` answered 200 ~10 s in; only the log's `Startup complete` is trustworthy. Seerr 503'd once in that window and its next sync completed.
- Both documented in `docs/UPGRADING.md`; changelog `[Unreleased]` covers the whole batch since 1.10.1.

## Verified

- `npm run test:e2e` after the config restore:  1 skipped 38 passed (1.4m) 
- Seerr → Jellyfin sync: `Recently Added Scan Complete` post-restart

**Not verifiable server-side:** a real play on the Fire TV Cube (12.0 also "disables deprecated authorization mechanisms"). Worth one manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
