### PR TITLE
Docs and changelog for 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [1.11.0] - 2026-09-10
 
 A public indexer served malware for a day, the stack's defences held, and the tool meant to preview changes turned out to be incapable of previewing anything.
 

--- a/docs/APP-CONFIG-QUICK.md
+++ b/docs/APP-CONFIG-QUICK.md
@@ -2,7 +2,7 @@
 
 > Return to [Setup Guide](SETUP.md) · [Manual setup instead?](APP-CONFIG.md)
 
-The [configure-apps.sh](../scripts/configure-apps.sh) script automates ~22 configuration steps across qBittorrent, Sonarr, Radarr, Prowlarr, and Bazarr — root folders, download clients, naming schemes, NFO metadata, custom formats, delay profiles, subtitle sync, and more.
+The [configure-apps.sh](../scripts/configure-apps.sh) script automates ~30 configuration steps across qBittorrent, Sonarr, Radarr, Prowlarr, Bazarr and Pi-hole — root folders, download clients, naming schemes, NFO metadata, custom formats, delay profiles, subtitle sync and languages, qBittorrent's executable exclusion list, and more. `--dry-run` shows exactly what would change on your stack.
 
 > **Note:** This script is LLM-generated and human-reviewed. Best not to blindly run scripts from the internet — review [configure-apps.sh](../scripts/configure-apps.sh) for security before running it.
 
@@ -34,6 +34,7 @@ Create admin account when prompted.
 
 **Bazarr** — `http://NAS_IP:6767`
 Create admin account when prompted.
+Then Settings → Languages: tick **English** under *Languages Filter*, and under *Languages Profiles* add one profile — name it English, add English to it — and Save. The script sets that profile as the series/movie default and keeps its contents to English; it does not create it.
 
 ## Step 2: Run the script
 

--- a/docs/APP-CONFIG.md
+++ b/docs/APP-CONFIG.md
@@ -260,6 +260,8 @@ Manages torrent/Usenet indexers and syncs them to Sonarr/Radarr.
 
    > **Tested with:** NZBGeek (~$12/year, reliable). Free alternatives: DrunkenSlug, NZBFinder.
 
+   > **Public torrent indexers carry malware.** On 2026-09-10 one of them (LimeTorrents) answered five routine new-episode searches with ~1 GB Windows executables named after real release groups, plus two season packs labelled S06 that contained S05 — while every Usenet result in the same window was clean. If you add public indexers: rank a Usenet indexer above them (Indexers → edit → **Priority**; lower wins, and every indexer defaults to 25, so without this Usenet has no advantage), and leave YTS out of a TV setup entirely — it only carries movies, so anything it returns for a series is mislabelled. The stack's own defences, in order: qBittorrent drops executables before a byte transfers (set by `configure-apps.sh`), Sonarr/Radarr refuse to import a release containing one, and [`scan-executables.sh`](MAINTENANCE.md#executable-scan) finds anything that still reached disk.
+
 4. **Add FlareSolverr** (for protected torrent sites):
    - Settings → Indexers → Add FlareSolverr
    - Host: `http://localhost:8191` (FlareSolverr shares Gluetun's network with Prowlarr)

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -158,6 +158,23 @@ Removed releases are blocklisted so the same broken release won't be grabbed aga
 
 ---
 
+## Executable Scan
+
+Public torrent indexers sometimes serve a Windows executable padded to episode size and named after a real release group. qBittorrent rejects the usual extensions up front and Sonarr/Radarr refuse to import a release containing one — but a refused import leaves the payload in `/data/torrents`, inert on the NAS and one SMB browse away from a machine where it isn't. This reports anything already on disk:
+
+```bash
+./scripts/scan-executables.sh          # lists findings, exit 1 if any
+./scripts/scan-executables.sh --quiet  # findings only, for cron
+```
+
+Weekly is plenty. Pair it with an Uptime Kuma push monitor the same way as the VPN check, or just log it:
+
+```bash
+0 4 * * 0 $NAS_STACK_DIR/scripts/scan-executables.sh --quiet >> $NAS_STACK_DIR/logs/scan-executables.log 2>&1
+```
+
+Anything it finds: verify, delete, then blocklist the release in Sonarr/Radarr (Activity → Queue → remove with **Blocklist** ticked) so the same grab isn't repeated. The e2e suite asserts the same steady state in `tests/e2e/media-hygiene.spec.ts`.
+
 ## Health Checks
 
 All services have Docker healthchecks. Check status:

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -40,27 +40,53 @@ docker compose -f docker-compose.arr-stack.yml up -d  # Restarts containers with
 
 When upgrading across versions, check below for any action required.
 
-### Jellyfin 10.11 → 12.0 (image bump)
+### v1.10.1 → v1.11.0
 
-12.0 rewrites the database on first start and a backup is the only way back. Direct upgrade from 10.11.x is supported. Two things the release notes don't say, both hit on this stack on 2026-09-10:
+Hardening against poisoned public-indexer results, a `--dry-run` that works, and image bumps including **Jellyfin 12.0** — a major version that rewrites its database on first start. Order matters: fix Jellyfin's config *before* the new image boots.
 
-**1. Hardware transcoding settings are silently reset** if `encoding.xml` contains `<EncoderPreset xsi:nil="true" />` — which is what 10.11 writes when the preset was never touched. 12.0's parser rejects the empty value, logs a single `[ERR] Error loading configuration file: /config/config/encoding.xml`, and rewrites the file with defaults: acceleration `none`, VPP tonemapping off, HEVC encoding off, and hevc/vp9/vp8/mpeg2 dropped from hardware decoding. Playback keeps working — in software — so nothing alerts you. With Jellyfin stopped, fix the preset before pulling the new image:
+#### 1. Pull
 
 ```bash
+cd $NAS_STACK_DIR && git pull
+```
+
+#### 2. Jellyfin: fix the preset before 12.0 starts
+
+12.0 refuses to parse the `encoding.xml` that 10.11 writes when the encoder preset was never touched — `<EncoderPreset xsi:nil="true" />` is an empty value to its stricter parser. It logs one line, `[ERR] Error loading configuration file: /config/config/encoding.xml`, then **rewrites the file with defaults**: hardware acceleration `none`, VPP tonemapping off, HEVC encoding off, hevc/vp9/vp8/mpeg2 dropped from hardware decoding. Playback keeps working — in software — so nothing alerts you.
+
+Back up the config volume first (a 4 GB volume took ~13 minutes on the NAS), then fix the preset with Jellyfin stopped:
+
+```bash
+docker run --rm -v arr-stack_jellyfin-config:/src:ro -v /path/to/backups:/bak alpine \
+  tar czf /bak/jellyfin-config-backup-$(date +%Y%m%d-%H%M%S).tgz -C /src .
 docker stop jellyfin
 docker run --rm -v arr-stack_jellyfin-config:/src alpine \
   sed -i 's|<EncoderPreset xsi:nil="true" />|<EncoderPreset>auto</EncoderPreset>|' /src/config/encoding.xml
 ```
 
-If you have already upgraded, compare `/config/config/encoding.xml` against your backup's copy and put the values back (or re-enter them in Dashboard → Playback → Transcoding). Look for that `[ERR]` line in the first-boot log either way.
+Already on 12.0 and transcoding has quietly moved to the CPU? Compare `/config/config/encoding.xml` with your backup's copy and put the values back, or re-enter them in Dashboard → Playback → Transcoding.
 
-**2. The healthcheck goes green before the migration finishes.** `/health` answered 200 about ten seconds in; `Startup complete` arrived 3m41s later. `docker ps` reporting healthy is not the signal — wait for:
+#### 3. Recreate, and wait for the log — not the healthcheck
 
 ```bash
-docker logs jellyfin 2>&1 | grep "Startup complete"
+docker compose -f docker-compose.arr-stack.yml up -d
+docker logs -f jellyfin 2>&1 | grep -m1 "Startup complete"
 ```
 
-Seerr logs a `503` if its library sync lands in that window; it recovers on the next run. For scale: backing up a 4 GB config volume with `tar` from a throwaway container took about 13 minutes on the NAS.
+`/health` answered 200 about ten seconds into a migration that took 3m41s, so `docker ps` reports healthy long before the server is usable. Seerr logs a `503` if its sync lands in that window; it recovers on the next run.
+
+#### 4. Re-run the configuration script
+
+```bash
+./scripts/configure-apps.sh --dry-run   # preview — this now reports real deltas
+./scripts/configure-apps.sh
+```
+
+Two new steps: qBittorrent's executable exclusion list (`*.exe`, `*.scr`, … rejected at the metadata stage, before any bytes transfer), and Bazarr's subtitle languages — the script now enforces *what* the language profile contains, not just which profile is default. It restarts Bazarr only if it changed something.
+
+#### 5. Optional: indexer hygiene and a standing scan
+
+Using public torrent indexers? Read the note in [APP-CONFIG.md § 4.6](APP-CONFIG.md#46-prowlarr-indexer-manager) on what hit this stack and how to rank them. `scripts/scan-executables.sh` reports any executables already sitting under `/data`; [MAINTENANCE.md](MAINTENANCE.md#executable-scan) has the cron line.
 
 ### v1.7.9 → v1.7.10
 


### PR DESCRIPTION
Docs-only. Rolls the changelog to **1.11.0** and writes the upgrade path for everything merged since 1.10.1 (#30 hardening + dry-run fix, #31 routine bumps, #32 Jellyfin 12.0).

- `docs/UPGRADING.md` — `v1.10.1 → v1.11.0`, in the order that matters: fix `encoding.xml` before 12.0 boots, wait for the log not the healthcheck, re-run `configure-apps.sh`.
- `docs/APP-CONFIG.md` 4.6 — public torrent indexers serve malware; rank usenet above them (all default to priority 25); YTS is movies-only.
- `docs/MAINTENANCE.md` — "Executable Scan" section with cron line for `scan-executables.sh`.
- `docs/APP-CONFIG-QUICK.md` — accurate script summary; first-timers must create Bazarr's English profile (the script sets profile 1 as default and has never created it — pre-existing gap, script fix to follow separately).
- `CHANGELOG.md` — `[Unreleased]` → `[1.11.0] - 2026-09-10`.

Pre-commit link check passes. Tag + GitHub release follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
