### PR TITLE
configure-apps: create Bazarr's English language profile when none exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **`configure-apps.sh` creates Bazarr's English language profile when none exist.** The default-language step set both defaults to profile 1 and assumed it was there; a fresh Bazarr ships with no profiles, so on a first run the step reported success while pointing the defaults at nothing, and the languages step only ever pruned profiles that already existed. When `GET /api/system/languages/profiles` is empty the script now inserts the profile (and ticks English under Languages Filter) before setting it as the default. Bazarr's handler deletes any existing profileId left out of a `languages-profiles` POST, so the insert only fires on an empty list and can never drop one. Proven against a throwaway `bazarr:1.6.0`, never the live volume: fresh → created, second run → all skips, `--dry-run` on fresh → `Would:` and nothing written. `BAZARR_CONTAINER` / `BAZARR_PORT` env overrides let the Bazarr section target such an instance.
+
 ## [1.11.0] - 2026-09-10
 
 A public indexer served malware for a day, the stack's defences held, and the tool meant to preview changes turned out to be incapable of previewing anything.

--- a/docs/APP-CONFIG-QUICK.md
+++ b/docs/APP-CONFIG-QUICK.md
@@ -34,7 +34,7 @@ Create admin account when prompted.
 
 **Bazarr** — `http://NAS_IP:6767`
 Create admin account when prompted.
-Then Settings → Languages: tick **English** under *Languages Filter*, and under *Languages Profiles* add one profile — name it English, add English to it — and Save. The script sets that profile as the series/movie default and keeps its contents to English; it does not create it.
+The script creates an English language profile if Bazarr has none, sets it as the series/movie default and keeps its contents to English — nothing to do here. If you already have profiles but none is English, add one first: Settings → Languages, tick **English** under *Languages Filter*, add a profile named English containing English, and Save.
 
 ## Step 2: Run the script
 

--- a/docs/APP-CONFIG.md
+++ b/docs/APP-CONFIG.md
@@ -308,8 +308,14 @@ Automatically downloads subtitles for your media.
 2. **Enable Authentication:** Settings → General → Security → Forms
 3. **Connect to Sonarr:** Settings → Sonarr → Address `sonarr`, Port `8989` (Sonarr is on the bridge)
 4. **Connect to Radarr:** Settings → Radarr → Address `radarr`, Port `7878` (Radarr is on the bridge)
-5. **Add Providers:** Settings → Providers (OpenSubtitles, etc.)
-6. **Enable Subtitle Sync:** Settings → Subtitles → Subtitle Synchronization:
+5. **Languages:** Settings → Languages:
+   - Under *Languages Filter*, tick **English**
+   - Under *Languages Profiles*, add a profile named **English** containing English
+   - Under *Default Settings*, set that profile as the default for both **Series** and **Movies**, then Save
+
+   > A fresh Bazarr has no profiles at all, and the defaults point at nothing until one exists. `configure-apps.sh` creates this profile if none exist and sets it as the default.
+6. **Add Providers:** Settings → Providers (OpenSubtitles, etc.)
+7. **Enable Subtitle Sync:** Settings → Subtitles → Subtitle Synchronization:
    - **Subtitle Synchronization:** On — enables `ffsubsync` to re-time subtitles against the audio track
    - **Series Score Threshold:** On (default 90) — auto-syncs series subs scoring below this
    - **Movies Score Threshold:** On (default 70) — auto-syncs movie subs scoring below this

--- a/scripts/configure-apps.sh
+++ b/scripts/configure-apps.sh
@@ -12,6 +12,11 @@
 #   --dry-run       Preview what would be configured without making changes
 #   --verbose, -v   Print curl response bodies on failure (for debugging)
 #
+# Environment overrides:
+#   BAZARR_CONTAINER, BAZARR_PORT   Point the Bazarr section at another
+#                   container/port (default: bazarr, 6767). Lets the section be
+#                   tested against a throwaway instance instead of the live one.
+#
 # Safe to re-run: The script is idempotent — it skips anything already
 # configured and only applies missing settings. You can run it as many
 # times as needed without side effects.
@@ -55,6 +60,8 @@ SONARR_API_KEY=""
 RADARR_API_KEY=""
 PROWLARR_API_KEY=""
 BAZARR_API_KEY=""
+BAZARR_CONTAINER="${BAZARR_CONTAINER:-bazarr}"
+BAZARR_PORT="${BAZARR_PORT:-6767}"
 SABNZBD_API_KEY=""
 QBIT_USERNAME="${QBIT_USERNAME:-}"
 QBIT_PASSWORD="${QBIT_PASSWORD:-}"
@@ -113,7 +120,7 @@ fi
 echo ""
 
 # Check key containers are running
-REQUIRED_CONTAINERS="gluetun qbittorrent sonarr radarr prowlarr bazarr"
+REQUIRED_CONTAINERS="gluetun qbittorrent sonarr radarr prowlarr ${BAZARR_CONTAINER}"
 MISSING=""
 for c in $REQUIRED_CONTAINERS; do
     if ! docker ps --format '{{.Names}}' | grep -q "^${c}$"; then
@@ -174,7 +181,7 @@ else
 fi
 
 # Bazarr — apikey is on same line as key: "  apikey: abc123"
-BAZARR_API_KEY=$(docker exec bazarr grep '^\s*apikey:' /config/config/config.yaml 2>/dev/null | head -1 | sed 's/.*apikey:\s*//' | tr -d ' ' || true)
+BAZARR_API_KEY=$(docker exec "$BAZARR_CONTAINER" grep '^\s*apikey:' /config/config/config.yaml 2>/dev/null | head -1 | sed 's/.*apikey:\s*//' | tr -d ' ' || true)
 if [[ -z "$BAZARR_API_KEY" ]]; then
     fail "Could not discover Bazarr API key"
 else
@@ -429,7 +436,7 @@ configure_bazarr() {
         return
     fi
 
-    local BASE="http://${NAS_IP}:6767"
+    local BASE="http://${NAS_IP}:${BAZARR_PORT}"
     local AUTH="X-API-KEY: ${BAZARR_API_KEY}"
 
     if ! wait_for_service "Bazarr" "${BASE}/api/system/status"; then return; fi
@@ -601,11 +608,43 @@ print(' '.join(missing) if missing else 'MATCH')")
         fi
     fi
 
+    # --- English language profile (create when none exist) ---
+    #
+    # The default-language step below points both defaults at profile 1 and
+    # assumed it existed. A fresh Bazarr ships with no profiles at all, so on
+    # a first run that step reported success while pointing the defaults at
+    # nothing, and the languages step further down only prunes profiles that
+    # already exist — nothing ever created one. Bazarr's handler
+    # (api/system/settings.py) takes the INSERT branch for a profileId it has
+    # not seen and DELETES any existing profileId missing from the list, so
+    # this only ever sends when the list is empty: there is nothing to drop.
+    # `languages-enabled` is sent alongside because a profile can only search
+    # languages that are ticked under Languages Filter.
+    local existing_profiles profile_count
+    existing_profiles=$(api_get "${BASE}/api/system/languages/profiles" "$AUTH") || true
+    profile_count=$(json_extract "$existing_profiles" "print(len(data))")
+
+    if [[ -z "$profile_count" ]]; then
+        fail "Bazarr: could not read language profiles"
+    elif [[ "$profile_count" != "0" ]]; then
+        skip "Bazarr: English language profile"
+    else
+        local english_profile
+        english_profile='[{"profileId":1,"name":"English","cutoff":null,"items":[{"id":1,"language":"en","audio_exclude":"False","audio_only_include":"False","hi":"False","forced":"False"}],"mustContain":[],"mustNotContain":[],"originalFormat":0,"tag":null}]'
+        if bazarr_settings_post "$BASE" "$AUTH" "languages-enabled=en" "languages-profiles=${english_profile}"; then
+            ok "Bazarr: create English language profile"
+            needs_restart=true
+        else
+            fail "Bazarr: create English language profile"
+        fi
+    fi
+
     # --- Default subtitle language (English) ---
     #
-    # Profile 1 is the English language profile. Checking only
-    # serie_default_enabled left the movie half, and both profile ids,
-    # unverified — all three could be wrong and still report "configured".
+    # Profile 1 is the English language profile, created above when missing.
+    # Checking only serie_default_enabled left the movie half, and both
+    # profile ids, unverified — all three could be wrong and still report
+    # "configured".
     local lang_state
     lang_state=$(json_extract "$settings" "
 want = {
@@ -692,7 +731,7 @@ print(json.dumps(profiles))
     # Restart if any changes were made (never in a dry run — nothing was written)
     if $needs_restart && ! $DRY_RUN; then
         info "Restarting Bazarr to apply changes..."
-        docker restart bazarr >/dev/null 2>&1
+        docker restart "$BAZARR_CONTAINER" >/dev/null 2>&1
     fi
 }
 


### PR DESCRIPTION
The default-language step set both Bazarr defaults to profile 1 and assumed it existed. A fresh Bazarr has no profiles, so a first run reported success while pointing the defaults at nothing. When the profile list is empty the script now inserts an English profile (and ticks English under Languages Filter) before setting it as default. Idempotent, dry-run aware.

`BAZARR_CONTAINER` / `BAZARR_PORT` env overrides let the Bazarr section target a throwaway instance.

Verified on the NAS against a throwaway `bazarr:1.6.0` on a temporary volume (live volume untouched, live container never restarted):
- fresh → profile 1 "English" created, `en` enabled, series/movie defaults = 1
- second run → all 31 steps skip
- `--dry-run` on fresh → `Would: Bazarr: create English language profile`, nothing written

e2e: 38 passed, 1 skipped (killswitch, expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)